### PR TITLE
add kafka tracer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,5 @@ rvm:
 - 2.1
 - 1.9.3
 - jruby
-- jruby-head
+- jruby-1.7.21
+

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ where Rails.config.zipkin_tracer or config is a hash that can contain the follow
    response status, headers, and body; and can record annotations
  * `:filter_plugin` - plugin function which recieves Rack env and will skip tracing if it returns false
  * `:whitelist_plugin` - plugin function which recieves Rack env and will force sampling if it returns true
+ * `:zookeeper` - plugin function which uses zookeeper and kafka instead of scribe as the transport
 
 ## Warning
 
@@ -77,3 +78,22 @@ For example:
 
     # sample if request header specifies known device identifier
     lambda {|env| KNOWN_DEVICES.include?(env['HTTP_X_DEVICE_ID'])}
+
+### Kafka Tracer
+
+Kafka tracer inherits from Tracer which is found in Finagle.  It allows using Kafka as
+the transport instead of scribe.  If a config[:zookeeper] parameter is pass into the
+initialization of the RackHandler, then the gem will use Kafka.  Hermann is the kafka
+client library.  Hermann and the Scribe gems are optionally installed because we would
+only use one of the other.  In your application, you will need to explicitly install
+either Hermann or Scribe.
+
+Caveat: Hermann is only usable from within Jruby, due to its implementation of zookeeper
+based broker discovery being JVM based.
+
+```
+# zipkin-kafka-tracer requires at minimim Hermann 0.25.0 or later
+  gem 'hermann', '~> 0.25'
+# Install scribe
+  gem 'scribe', "~> 0.2.4"
+```

--- a/Rakefile
+++ b/Rakefile
@@ -15,6 +15,17 @@
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 
-RSpec::Core::RakeTask.new(:spec)
+def add_rspec_options(options=[])
+  if RUBY_PLATFORM == 'java'
+    options << '--tag ~platform:mri'
+  else
+    options << '--tag ~platform:java'
+  end
+  return options
+end
+
+RSpec::Core::RakeTask.new(:spec) do |r|
+  r.rspec_opts = add_rspec_options
+end
 
 task :default => :spec

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 module ZipkinTracer
-  VERSION = "0.2.1"
+  VERSION = "0.3.1"
 end
 

--- a/lib/zipkin-tracer/zipkin_kafka_tracer.rb
+++ b/lib/zipkin-tracer/zipkin_kafka_tracer.rb
@@ -1,0 +1,65 @@
+require 'finagle-thrift'
+require 'finagle-thrift/tracer'
+require 'hermann/producer'
+require 'hermann/discovery/zookeeper'
+
+module Trace
+  class ZipkinKafkaTracer < Tracer
+    TRACER_CATEGORY     = "zipkin".freeze
+    DEFAULT_KAFKA_TOPIC = "zipkin_kafka".freeze
+
+    def initialize(opts={})
+      @logger = opts[:logger]
+      @topic  = opts[:topic] || DEFAULT_KAFKA_TOPIC
+      reset
+    end
+
+    # need to connect after initialization
+    def connect(zookeepers)
+      broker_ids = Hermann::Discovery::Zookeeper.new(zookeepers).get_brokers
+      @producer  = Hermann::Producer.new(nil, broker_ids)
+    end
+
+    def record(id, annotation)
+      return unless id.sampled?
+      span = get_span_for_id(id)
+
+      case annotation
+      when BinaryAnnotation
+        span.binary_annotations << annotation
+      when Annotation
+        span.annotations << annotation
+      end
+
+      flush!
+    end
+
+    def set_rpc_name(id, name)
+      return unless id.sampled?
+      span = get_span_for_id(id)
+      span.name = name.to_s
+    end
+
+    private
+      def reset
+        @spans = {}
+      end
+
+      def get_span_for_id(id)
+        key = id.span_id.to_s
+        @spans[key] ||= begin
+          Span.new("", id)
+        end
+      end
+
+      def flush!
+        messages = @spans.values.map do |span|
+          buf = ''
+          trans = Thrift::MemoryBufferTransport.new(buf)
+          oprot = Thrift::BinaryProtocol.new(trans)
+          span.to_thrift.write(oprot)
+          @producer.push(buf, :topic => @topic).value!
+        end
+      end
+  end
+end

--- a/spec/rack_handler_spec.rb
+++ b/spec/rack_handler_spec.rb
@@ -22,6 +22,18 @@ describe ZipkinTracer::RackHandler do
     allow(::Trace::Endpoint).to receive(:host_to_i32).and_return(host_ip)
   }
 
+  context 'configured to use kafka', :platform => :java do
+    let(:zookeeper) { 'localhost:2181' }
+    let(:zipkinKafkaTracer) { double('ZipkinKafkaTracer') }
+
+    it 'creates a zipkin kafka tracer' do
+      allow(::Trace::ZipkinKafkaTracer).to receive(:new) { zipkinKafkaTracer }
+      expect(::Trace).to receive(:tracer=).with(zipkinKafkaTracer)
+      expect(zipkinKafkaTracer).to receive(:connect)
+      middleware(app, :zookeeper => zookeeper)
+    end
+  end
+
   context 'configured without plugins' do
     subject { middleware(app) }
 
@@ -48,7 +60,6 @@ describe ZipkinTracer::RackHandler do
           expect(trace_id.sampled?).to be_falsy
         end
         status, headers, body = subject.call(mock_env())
-
         # return expected status
         expect(status).to eq(200)
       end

--- a/spec/zipkin_kafka_tracer_spec.rb
+++ b/spec/zipkin_kafka_tracer_spec.rb
@@ -1,0 +1,106 @@
+require 'spec_helper'
+
+# needed the if statement because rspec tags are broken
+if RUBY_PLATFORM == 'java'
+  describe Trace::ZipkinKafkaTracer, :platform => :java do
+    let(:id)   { double('id') }
+    let(:span) { double('span') }
+
+    describe '#initialize' do
+      context 'with default settings' do
+        it 'has nil logger' do
+          expect(subject.instance_variable_get(:@logger)).to be nil
+        end
+        it 'has default topic' do
+          expect(subject.instance_variable_get(:@topic)).to eq Trace::ZipkinKafkaTracer::DEFAULT_KAFKA_TOPIC
+        end
+        it 'initializes instance variables' do
+          expect(subject.instance_variable_get(:@spans)).to be_a(Hash)
+          expect(subject.instance_variable_get(:@spans).length).to eq 0
+        end
+      end
+
+      context 'with options' do
+        let(:logger) { double('logger') }
+        let(:topic)  { 'topic' }
+
+        subject { described_class.new({:logger => logger, :topic => topic}) }
+
+        it 'has logger' do
+          expect(subject.instance_variable_get(:@logger)).to be logger
+        end
+        it 'has an optional topic' do
+          expect(subject.instance_variable_get(:@topic)).to eq topic
+        end
+      end
+    end
+
+    describe '#connect' do
+      let(:zookeepers) { 'localhost:2181'     }
+      let(:zk)         { double('broker_ids') }
+      let(:producer)   { double('producer')   }
+
+      it 'connects to zookeeper to create the producer' do
+        allow(Hermann::Discovery::Zookeeper).to receive(:new) { zk }
+        allow(zk).to receive(:get_brokers)
+        allow(Hermann::Producer).to receive(:new) { producer }
+        subject.connect(zookeepers)
+        expect(subject.instance_variable_get(:@producer)).to eq producer
+      end
+    end
+
+    describe '#record' do
+      module MockTrace
+        class BinaryAnnotation < Trace::BinaryAnnotation
+          def initialize;end
+        end
+        class Annotation < Trace::Annotation
+          def initialize;end
+        end
+      end
+
+      let(:binary_annotation) { MockTrace::BinaryAnnotation.new }
+      let(:annotation)        { MockTrace::Annotation.new }
+
+      it 'returns if id already sampled' do
+        allow(id).to receive(:sampled?) { false }
+        expect(subject).to_not receive(:get_span_for_id)
+        subject.record(id, annotation)
+      end
+
+      context 'processing annotation' do
+        before do
+          allow(id).to receive(:sampled?) { true }
+          allow(subject).to receive(:get_span_for_id) { span }
+          expect(subject).to receive(:flush!)
+        end
+
+        it 'records a binary annotation' do
+          expect(span).to receive(:binary_annotations) { [] }
+          subject.record(id, binary_annotation)
+        end
+        it 'records an annotation' do
+          expect(span).to receive(:annotations) { [] }
+          subject.record(id, annotation)
+        end
+      end
+    end
+
+    describe '#set_rpc_name' do
+      let(:name) { 'name' }
+
+      it 'returns if id already sampled' do
+        allow(id).to receive(:sampled?) { false }
+        expect(subject).to_not receive(:get_span_for_id)
+        subject.set_rpc_name(id, name)
+      end
+
+      it 'sets the span name' do
+        allow(id).to receive(:sampled?) { true }
+        allow(subject).to receive(:get_span_for_id) { span }
+        expect(span).to receive(:name=).with(name)
+        subject.set_rpc_name(id, name)
+      end
+    end
+  end
+end

--- a/zipkin-tracer.gemspec
+++ b/zipkin-tracer.gemspec
@@ -20,8 +20,8 @@ require 'zipkin-tracer/version'
 Gem::Specification.new do |s|
   s.name                      = "zipkin-tracer"
   s.version                   = ZipkinTracer::VERSION
-  s.authors                   = ["Franklin Hu", "R Tyler Croy"]
-  s.email                     = ["franklin@twitter.com", 'tyler@monkeypox.org']
+  s.authors                   = ["Franklin Hu", "R Tyler Croy", "James Way"]
+  s.email                     = ["franklin@twitter.com", 'tyler@monkeypox.org', 'jamescway@gmail.com']
   s.homepage                  = 'https://github.com/openzipkin/zipkin-tracer'
   s.summary                   = "Ruby tracing via Zipkin"
   s.description               = "Adds tracing instrumentation for ruby applications"
@@ -39,4 +39,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rack-test"
   s.add_development_dependency "rake"
   s.add_development_dependency "pry"
+
+  s.add_development_dependency 'hermann', "~> 0.25"
+  s.add_development_dependency "scribe", "~> 0.2.4"
 end


### PR DESCRIPTION
Adding Kafka tracer functionality and documentation.  Allows using Kafka as the transport instead of scribe.

Caveat: This implementation can only be used by Jruby (JVM based) and will not be usable by MRI ruby.