### PR TITLE
Use finagle-thrift ~> 1.4.1

### DIFF
--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 module ZipkinTracer
-  VERSION = "0.3.1"
+  VERSION = "0.4.0"
 end
 

--- a/zipkin-tracer.gemspec
+++ b/zipkin-tracer.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.files                     = Dir.glob("{bin,lib}/**/*")
   s.require_path              = 'lib'
 
-  s.add_dependency "finagle-thrift", "~> 1.3.0"
+  s.add_dependency "finagle-thrift", "~> 1.4.1"
   s.add_dependency "scribe", "~> 0.2.4"
   s.add_dependency "rack"
 
@@ -41,5 +41,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency "pry"
 
   s.add_development_dependency 'hermann', "~> 0.25"
-  s.add_development_dependency "scribe", "~> 0.2.4"
 end


### PR DESCRIPTION
Makes the trace handling thread safe and suppresses Hash deprecation warnings.

See also https://github.com/twitter/finagle/commit/086f36280d95ce56e9a30eda789c983ae79b82ec

Bumped to 0.4.0 because finagle-thrift went from 1.3.x to 1.4.x.

Took the opportunity to remove the redundant scribe dependency in the gemspec.