### PR TITLE
add logger support and rescue all exceptions. Safety first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+#0.6
+New configuration option :logger to setup a logger for error messages
+The Zipkin Rack middleware will not raise an error if sending information to Zipkin raises an error
+
 #0.5.1
 The Zipkin Rack middleware will not raise an error if sending information to Zipkin raises an error
 Integration specs to make sure information is properly passed when using Rack middleware together with Faraday's

--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ where Rails.config.zipkin_tracer or config is a hash that can contain the follow
  * `:filter_plugin` - plugin function which recieves Rack env and will skip tracing if it returns false
  * `:whitelist_plugin` - plugin function which recieves Rack env and will force sampling if it returns true
  * `:zookeeper` - plugin function which uses zookeeper and kafka instead of scribe as the transport
+ * `:logger` - A logger class following the standard's library Logger interface (Log4r, Rails.logger, etc).
+
+
+ If The configuration do not provide a Scribe or a Zookeeper servers, then the middlewares will not
+ attempt to send traces. But they will still generate proper IDs and pass them to other services.
+ Thus, if you only want to generate IDs for instance for logging and do not intent to integrate with Zipkin,
+ you can still use this gem. Just do not specify any server :)
+
 
 ### Warning
 

--- a/lib/zipkin-tracer.rb
+++ b/lib/zipkin-tracer.rb
@@ -1,3 +1,4 @@
+require 'base64' #Bug in finagle. They should be requiring this: finagle-thrift-1.4.1/lib/finagle-thrift/tracer.rb:115
 require 'zipkin-tracer/rack/zipkin-tracer'
 
 begin

--- a/lib/zipkin-tracer/config.rb
+++ b/lib/zipkin-tracer/config.rb
@@ -1,8 +1,9 @@
+require 'logger'
 module ZipkinTracer
 
   class Config
     attr_reader :service_name, :service_port, :scribe_server, :zookeeper, :sample_rate,
-      :scribe_max_buffer, :annotate_plugin, :filter_plugin, :whitelist_plugin
+      :scribe_max_buffer, :annotate_plugin, :filter_plugin, :whitelist_plugin, :logger
 
     def initialize(app, config_hash)
       config = config_hash || app_config(app)
@@ -15,6 +16,7 @@ module ZipkinTracer
       @annotate_plugin   = config[:annotate_plugin]   # call for trace annotation
       @filter_plugin     = config[:filter_plugin]     # skip tracing if returns false
       @whitelist_plugin  = config[:whitelist_plugin]  # force sampling if returns true
+      @logger            = config[:logger]            || fallback_logger
     end
 
     def using_scribe?
@@ -26,6 +28,14 @@ module ZipkinTracer
     end
 
     private
+
+    def fallback_logger
+      if defined?(Rails) # If we happen to be inside a Rails app, use its logger
+        Rails.logger
+      else
+        Logger.new(STDOUT)
+      end
+    end
 
     DEFAULTS = {
       scribe_max_buffer: 10,

--- a/lib/zipkin-tracer/faraday/zipkin-tracer.rb
+++ b/lib/zipkin-tracer/faraday/zipkin-tracer.rb
@@ -33,15 +33,23 @@ module ZipkinTracer
 
         # annotate with method (GET/POST/etc.) and uri path
         ::Trace.set_rpc_name(env[:method].to_s.upcase)
-        ::Trace.record(::Trace::BinaryAnnotation.new("http.uri", url.path, "STRING", endpoint))
-        ::Trace.record(::Trace::Annotation.new(::Trace::Annotation::CLIENT_SEND, endpoint))
+        record(::Trace::BinaryAnnotation.new("http.uri", url.path, "STRING", endpoint))
+        record(::Trace::Annotation.new(::Trace::Annotation::CLIENT_SEND, endpoint))
         result = @app.call(env).on_complete do |renv|
           # record HTTP status code on response
-          ::Trace.record(::Trace::BinaryAnnotation.new("http.status", [renv[:status]].pack('n'), "I16", endpoint))
+          record(::Trace::BinaryAnnotation.new("http.status", [renv[:status]].pack('n'), "I16", endpoint))
         end
-        ::Trace.record(::Trace::Annotation.new(::Trace::Annotation::CLIENT_RECV, endpoint))
+        record(::Trace::Annotation.new(::Trace::Annotation::CLIENT_RECV, endpoint))
         result
       end
+    end
+
+    private
+
+    def record(annotation)
+      ::Trace.record(annotation)
+    rescue Exception # Sockets errors inherit from Exception, not from StandardError
+      #TODO: if this class some day accepts a config hash, add a logger
     end
 
     # get host IP for specified hostname, catching exceptions
@@ -51,6 +59,6 @@ module ZipkinTracer
       # default to 0.0.0.0 if lookup fails
       0x00000000
     end
-    private :host_ip_for
+
   end
 end

--- a/lib/zipkin-tracer/rack/zipkin-tracer.rb
+++ b/lib/zipkin-tracer/rack/zipkin-tracer.rb
@@ -94,7 +94,10 @@ module ZipkinTracer extend self
       @lock.synchronize do
         yield
       end
-    rescue# Nothing wonky that the tracer does should stop us from using the app!!!
+    # Nothing wonky that the tracer does should stop us from using the app!!!
+    # Usually is better to rescue StandardError but the socket layer can launch Errno kind of exceptions
+    rescue Exception => e
+      @config.logger.error("Exception #{e.message} while sending Zipkin traces. #{e.backtrace}")
     end
 
     def get_or_create_trace_id(env, whitelisted, default_flags = ::Trace::Flags::EMPTY)

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 module ZipkinTracer
-  VERSION = "0.5.1"
+  VERSION = "0.6"
 end
 

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -15,9 +15,9 @@ describe 'integrations' do
     @port2 = 4445
     @base_url2 = "http://localhost:#{@port2}"
     @pipe2 = IO.popen("rackup #{ru_location} -p #{@port2}")
-    sleep(1)
+    sleep(2)
     if RUBY_PLATFORM == 'java'
-      sleep(10) #Jruby starts slow
+      sleep(20) #Jruby starts slow
     end
 
   end

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -10,7 +10,8 @@ end
 module ZipkinTracer
   RSpec.describe Config do
     [:service_name, :service_port, :scribe_server, :zookeeper, :sample_rate,
-      :scribe_max_buffer, :annotate_plugin, :filter_plugin, :whitelist_plugin].each do |method|
+     :scribe_max_buffer, :annotate_plugin, :filter_plugin, :whitelist_plugin,
+     :logger ].each do |method|
       it "can set and read configuration values for #{method}" do
         value = rand(100)
         config = Config.new(nil, {method => value})
@@ -27,6 +28,23 @@ module ZipkinTracer
       config = Config.new(nil, {})
       expect(config.scribe_max_buffer).to_not eq(nil)
     end
+
+    describe 'logger' do
+
+      it 'uses Rails logger if available' do
+        logger = 'TrusmisLogger'
+        object_double("Rails", logger: logger).as_stubbed_const
+
+        config = Config.new(nil, {})
+        expect(config.logger).to eq(logger)
+      end
+
+      it 'uses STDOUT if nothing was provided and not using rails' do
+        config = Config.new(nil, {})
+        expect(config.logger).to be_kind_of(Logger)
+      end
+    end
+
 
     describe '#using_scribe?' do
       it 'returns false if scribe server has not been set' do

--- a/spec/lib/faraday/zipkin-tracer_spec.rb
+++ b/spec/lib/faraday/zipkin-tracer_spec.rb
@@ -107,6 +107,12 @@ describe ZipkinTracer::FaradayHandler do
         process('', url)
       end
     end
+
+    it 'does not allow exceptions to raise to the application when ::Trace.record raises' do
+      allow(::Trace).to receive(:record).and_raise(Errno::EBADF)
+      expect{process('', url)}.not_to raise_error
+    end
+
   end
 
   context 'middleware configured (without service_name)' do

--- a/spec/lib/rack/zipkin-tracer_spec.rb
+++ b/spec/lib/rack/zipkin-tracer_spec.rb
@@ -34,8 +34,9 @@ describe ZipkinTracer::RackHandler do
     end
   end
 
+
   context 'configured without plugins' do
-    subject { middleware(app) }
+    subject { middleware(app, logger: Logger.new(nil)) }
 
     it 'traces a request' do
       expect(::Trace).to receive(:push).ordered
@@ -50,7 +51,7 @@ describe ZipkinTracer::RackHandler do
     end
 
     it 'calls the app even when the tracer raises while the call method is called' do
-      allow(::Trace).to receive(:record).and_raise(RuntimeError)
+      allow(::Trace).to receive(:record).and_raise(Errno::EBADF)
       status, headers, body = subject.call(mock_env)
       # return expected status
       expect(status).to eq(200)

--- a/spec/support/test_app_config.ru
+++ b/spec/support/test_app_config.ru
@@ -6,6 +6,7 @@ zipkin_tracer_config = {
   service_name: 'your service name here',
   service_port: 9410,
   sample_rate: 1,
+  scribe_max_buffer: 1,
   scribe_server: '127.0.0.1:9410'
 }
 


### PR DESCRIPTION
- Rescue low level errors in both middlewares
- Added a logger configuration option so we can log errors.
- Log exceptions
- Added an explanation about what will happen if no server information is configured in the gem

@adriancole  @jamescway 