### PR TITLE
relax rack constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#0.6.1
+Relax constraint on Rack from ~>1.6 to ~>1.5
+
 #0.6
 New configuration option :logger to setup a logger for error messages
 The Zipkin Rack middleware will not raise an error if sending information to Zipkin raises an error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 #0.6.1
-Relax constraint on Rack from ~>1.6 to ~>1.5
+Relax constraint on Rack from ~>1.6 to ~>1.3
 
 #0.6
 New configuration option :logger to setup a logger for error messages

--- a/zipkin-tracer.gemspec
+++ b/zipkin-tracer.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "finagle-thrift", "~> 1.4.1"
   s.add_dependency "scribe", "~> 0.2.4"
-  s.add_dependency "rack", "~> 1.6"
+  s.add_dependency "rack", "~> 1.5"
 
   s.add_development_dependency "rspec", "~> 3.3"
   s.add_development_dependency "rack-test", "~> 0.6"

--- a/zipkin-tracer.gemspec
+++ b/zipkin-tracer.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "finagle-thrift", "~> 1.4.1"
   s.add_dependency "scribe", "~> 0.2.4"
-  s.add_dependency "rack", "~> 1.5"
+  s.add_dependency "rack", "~> 1.3"
 
   s.add_development_dependency "rspec", "~> 3.3"
   s.add_development_dependency "rack-test", "~> 0.6"


### PR DESCRIPTION
@adriancole @jamescway 

We do not really need Rack 1.6, not using any of the new functionality there. A dependency on 1.6 implies the middleware can only be used with Rails 4.2 or above.
Relaxing to rack 1.3. This allows using any version since Rails 3.1
