### PR TITLE
make hermann a dependency

### DIFF
--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 module ZipkinTracer
-  VERSION = "0.7"
+  VERSION = "0.7.1"
 end
 

--- a/zipkin-tracer.gemspec
+++ b/zipkin-tracer.gemspec
@@ -32,7 +32,6 @@ Gem::Specification.new do |s|
   s.require_path              = 'lib'
 
   s.add_dependency "finagle-thrift", "~> 1.4.1"
-  s.add_dependency "scribe", "~> 0.2.4"
   s.add_dependency "rack", "~> 1.3"
   s.add_dependency 'sucker_punch', '~> 1.0'
 
@@ -41,5 +40,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake", '~> 10.0'
   s.add_development_dependency "pry", '~> 0.10'
   s.add_development_dependency "faraday", '~> 0.8'
+
+  # install one or the other (Scribe or Hermann)
   s.add_development_dependency 'hermann', "~> 0.25"
+  s.add_development_dependency "scribe", "~> 0.2.4"
 end


### PR DESCRIPTION
Removing scribe as an explicit dependency.  In the readme, it states that the user should explicitly install their transport of choice.