### PR TITLE
only trace valid requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#0.6.2
+Do not trace requests if the current application will not serve them.
+
 #0.6.1
 Relax constraint on Rack from ~>1.6 to ~>1.3
 

--- a/lib/zipkin-tracer/rack/zipkin-tracer.rb
+++ b/lib/zipkin-tracer/rack/zipkin-tracer.rb
@@ -49,7 +49,7 @@ module ZipkinTracer extend self
 
     def call(env)
       # skip certain requests
-      return @app.call(env) if filtered?(env) || !valid_request?(env)
+      return @app.call(env) if filtered?(env) || !routable_request?(env)
 
       ::Trace.default_endpoint = ::Trace.default_endpoint.with_service_name(@config.service_name).with_port(@config.service_port)
       ::Trace.sample_rate=(@config.sample_rate)
@@ -61,7 +61,7 @@ module ZipkinTracer extend self
     private
 
     # If the request is not valid for this service, we do not what to trace it.
-    def valid_request?(env)
+    def routable_request?(env)
       return true unless defined?(Rails) #If not running on a Rails app, we can't verify if it is invalid
       Rails.application.routes.recognize_path(env["PATH_INFO"])
       true

--- a/lib/zipkin-tracer/rack/zipkin-tracer.rb
+++ b/lib/zipkin-tracer/rack/zipkin-tracer.rb
@@ -49,7 +49,7 @@ module ZipkinTracer extend self
 
     def call(env)
       # skip certain requests
-      return @app.call(env) if filtered?(env)
+      return @app.call(env) if filtered?(env) || !valid_request?(env)
 
       ::Trace.default_endpoint = ::Trace.default_endpoint.with_service_name(@config.service_name).with_port(@config.service_port)
       ::Trace.sample_rate=(@config.sample_rate)
@@ -59,6 +59,16 @@ module ZipkinTracer extend self
     end
 
     private
+
+    # If the request is not valid for this service, we do not what to trace it.
+    def valid_request?(env)
+      return true unless defined?(Rails) #If not running on a Rails app, we can't verify if it is invalid
+      Rails.application.routes.recognize_path(env["PATH_INFO"])
+      true
+    rescue ActionController::RoutingError
+      false
+    end
+
     def annotate(env, status, response_headers, response_body)
       @config.annotate_plugin.call(env, status, response_headers, response_body) if @config.annotate_plugin
     end

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 module ZipkinTracer
-  VERSION = "0.6.1"
+  VERSION = "0.6.2"
 end
 


### PR DESCRIPTION

Realized while looking at the traces that we had bunch of traces for weird URLs.
Turns out is people trying to find security holes in our apps.
We do not want to send those all traces to our zipkin. This PR solves the problem for Rails apps.

@jamescway @jfeltesse-mdsol 