### PR TITLE
faraday should pop the stack properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#0.6.3
+Properly pop the Id from the traces stacks when finishing the Faraday tracer
+
 #0.6.2
 Do not trace requests if the current application will not serve them.
 

--- a/lib/zipkin-tracer/config.rb
+++ b/lib/zipkin-tracer/config.rb
@@ -8,7 +8,7 @@ module ZipkinTracer
     def initialize(app, config_hash)
       config = config_hash || app_config(app)
       @service_name      = config[:service_name]
-      @service_port      = config[:service_port]
+      @service_port      = config[:service_port]      || DEFAULTS[:service_port]
       @scribe_server     = config[:scribe_server]
       @zookeeper         = config[:zookeeper]
       @sample_rate       = config[:sample_rate]       || DEFAULTS[:sample_rate]
@@ -39,7 +39,8 @@ module ZipkinTracer
 
     DEFAULTS = {
       scribe_max_buffer: 10,
-      sample_rate: 0.1
+      sample_rate: 0.1,
+      service_port: 80
     }
 
     def app_config(app)

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 module ZipkinTracer
-  VERSION = "0.6.2"
+  VERSION = "0.6.3"
 end
 

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -29,6 +29,11 @@ module ZipkinTracer
       expect(config.scribe_max_buffer).to_not eq(nil)
     end
 
+    it 'sets defaults for service_port' do
+      config = Config.new(nil, {})
+      expect(config.service_port).to_not eq(nil)
+    end
+
     describe 'logger' do
 
       it 'uses Rails logger if available' do


### PR DESCRIPTION
@jamescway 
Faraday was not properly restoring the spanID after it created a new one in a faraday outbound connection. 
This solves that bug