### PR TITLE
tracing does not wait for ack and connection moved to a different thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+#0.7
+The ruby client does not wait to receive ACK from the collector. Just send traces
+Connecting to the collector now happens in a different thread
+The server annotations will not add information about the URL hit if hit by a zipkin enabled client
+
 #0.6.3
 Properly pop the Id from the traces stacks when finishing the Faraday tracer
 

--- a/lib/zipkin-tracer/careless_scribe.rb
+++ b/lib/zipkin-tracer/careless_scribe.rb
@@ -1,35 +1,70 @@
 # Copyright 2012 Twitter Inc.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require 'sucker_punch'
+
+
+module ScribeThrift
+  # This is here just for the monkey partching
+  class Client
+    # This method in the original class was both sending and receiving logs.
+    # The original class: https://github.com/twitter/scribe/blob/master/vendor/gen-rb/scribe.rb
+    # Receiving logs may take even several seconds, depending on the buffering of the collector.
+    # We are just sending and forgetting here, we do not really care about the result
+    def Log(messages)
+      send_Log(messages)
+      0 # 0 means success , the original code called recv_Log()
+    end
+  end
+end
+
+# SuckerPunch creates a queue and a thread pool to work on jobs on the queue
+# calling perform adds the code to the queue
+class AsyncScribe
+  include SuckerPunch::Job
+
+  PROTOCOL_TIMEOUT = 10  # If the timeout is low, the protocol will lose spans when collector is not fast enough
+  CATEGORY = 'ruby'       # Thrift-client already uses this as default, seems to not affect anything
+  ADD_NEWLINES_TO_MESSAGES = true  # True is the default in Thrift-client, seems a necessary internal hack
+
+  def perform(server_address, *args)
+    # May seem wasteful to open a new connection per each span but the way the scribe is done
+    # it is difficult to ensure there will be no threading issues unless we create here the connection
+    scribe = Scribe.new(server_address, CATEGORY, ADD_NEWLINES_TO_MESSAGES, timeout: PROTOCOL_TIMEOUT)
+    scribe.log(*args)
+  rescue ThriftClient::NoServersAvailable, Thrift::Exception
+    # I couldn't care less
+  end
+
+end
+
+# Scribe which rescue thrift errors to avoid them to raise to the client
 class CarelessScribe
-  def initialize(scribe)
-    @scribe = scribe
+
+  def initialize(scribe_server_address)
+    @server_address = scribe_server_address
   end
 
   def log(*args)
-    @scribe.log(*args)
-  rescue ThriftClient::NoServersAvailable, Thrift::Exception
-    # I couldn't care less
+    AsyncScribe.new.async.perform(@server_address, *args)
   end
 
   def batch(&block)
-    @scribe.batch(&block)
+    yield   #We just yield here
+    # the block finagle-thrift-1.4.1/lib/finagle-thrift/tracer.rb flush! method will call log also.
   rescue ThriftClient::NoServersAvailable, Thrift::Exception
     # I couldn't care less
   end
 
-  def method_missing(name, *args)
-    @scribe.send(name, *args)
-  end
 end

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 module ZipkinTracer
-  VERSION = "0.6.3"
+  VERSION = "0.7"
 end
 

--- a/zipkin-tracer.gemspec
+++ b/zipkin-tracer.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |s|
   s.add_dependency "finagle-thrift", "~> 1.4.1"
   s.add_dependency "scribe", "~> 0.2.4"
   s.add_dependency "rack", "~> 1.3"
+  s.add_dependency 'sucker_punch', '~> 1.0'
 
   s.add_development_dependency "rspec", "~> 3.3"
   s.add_development_dependency "rack-test", "~> 0.6"


### PR DESCRIPTION
Big PR but had to be done this way.

This solves a big issue with the connection between the client and the collector.
The client was waiting for the collector to send back ack saying the spans were saved, that was too slow to the point most spans were timing out.

Now we do not wait. Also we connect in a different thread so we do not slow down the main request.

Also added some new specs and moved code to initializers instead of calling every time if possible.

@jamescway 