### PR TITLE
rescue errors when lookup of the host fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.7.2
+Rescue possible errors when lookup of the hostname fails
+
+# 0.7.1
+Remove Scribe from direct dependencies list
+
 #0.7
 The ruby client does not wait to receive ACK from the collector. Just send traces
 Connecting to the collector now happens in a different thread

--- a/lib/zipkin-tracer/rack/zipkin-tracer.rb
+++ b/lib/zipkin-tracer/rack/zipkin-tracer.rb
@@ -44,7 +44,7 @@ module ZipkinTracer extend self
       else
         ::Trace::NullTracer.new
       end
-      ::Trace.default_endpoint = ::Trace.default_endpoint.with_service_name(config.service_name).with_port(config.service_port)
+      ::Trace.default_endpoint = ::Trace::Endpoint.new( local_ip, config.service_port , config.service_name)
       ::Trace.sample_rate=(config.sample_rate)
 
       @config = config
@@ -134,6 +134,14 @@ module ZipkinTracer extend self
 
       Trace::TraceId.new(*trace_parameters)
     end
+
+    def local_ip
+      ::Trace::Endpoint.host_to_i32(Socket.gethostname)
+    rescue
+      # Default to local if lockup fails
+      ::Trace::Endpoint.host_to_i32('127.0.0.1')
+    end
+
   end
 
 end

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 module ZipkinTracer
-  VERSION = "0.7.1"
+  VERSION = "0.7.2"
 end
 


### PR DESCRIPTION
This error happens when running the code inside a VPN. I'm not big on networks but I've seen it myself and some other people also. The error happens using Socket.gethostname. We are rescuing that now. (before it was happening inside default_endpoint)
@jamescway @adriancole 