### PR TITLE
Sa annotated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.8.0
+To proper follow the correct spec, now the annotations cr/cs set the local service as servicename
+Added a 'sa' annotation to indicate the remote service servicename
+
 # 0.7.3
 Send method name (get, post, etc) as lowercase (zipkin > 1.22 expect them lowercase)
 

--- a/lib/zipkin-tracer/faraday/zipkin-tracer.rb
+++ b/lib/zipkin-tracer/faraday/zipkin-tracer.rb
@@ -34,7 +34,7 @@ module ZipkinTracer
         # annotate with method (GET/POST/etc.) and uri path
         ::Trace.set_rpc_name(env[:method].to_s.downcase)
         record(::Trace::BinaryAnnotation.new("http.uri", url.path, "STRING", local_endpoint))
-        record(::Trace::BinaryAnnotation.new("sa", "1", "BYTE", remote_endpoint))
+        record(::Trace::BinaryAnnotation.new("sa", "1", "BOOL", remote_endpoint))
         record(::Trace::Annotation.new(::Trace::Annotation::CLIENT_SEND, local_endpoint))
         response = @app.call(env).on_complete do |renv|
           # record HTTP status code on response

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 module ZipkinTracer
-  VERSION = "0.7.3"
+  VERSION = "0.8.0"
 end
 


### PR DESCRIPTION
Previously we were sending CS/CR with the name of the service we were calling.
Turns out this is incorrect.
Now we do CS/CR with the local server and we are sending an extra annotation (SA) with the name of the service we are callling
@jamescway  @adriancole 