### PR TITLE
Set caller service name using domain environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.8.1
+Set caller service name using domain environment variable. If the value
+is not set, it will fall back to the configuration file default.
+
 # 0.8.0
 To proper follow the correct spec, now the annotations cr/cs set the local service as servicename
 Added a 'sa' annotation to indicate the remote service servicename

--- a/lib/zipkin-tracer/faraday/zipkin-tracer.rb
+++ b/lib/zipkin-tracer/faraday/zipkin-tracer.rb
@@ -6,14 +6,14 @@ require 'uri'
 module ZipkinTracer
   class FaradayHandler < ::Faraday::Middleware
     B3_HEADERS = {
-      :trace_id => "X-B3-TraceId",
-      :parent_id => "X-B3-ParentSpanId",
-      :span_id => "X-B3-SpanId",
-      :sampled => "X-B3-Sampled",
-      :flags => "X-B3-Flags"
+      trace_id: 'X-B3-TraceId',
+      parent_id: 'X-B3-ParentSpanId',
+      span_id: 'X-B3-SpanId',
+      sampled: 'X-B3-Sampled',
+      flags: 'X-B3-Flags'
     }.freeze
 
-    def initialize(app, service_name=nil)
+    def initialize(app, service_name = nil)
       @app = app
       @service_name = service_name
     end
@@ -22,7 +22,7 @@ module ZipkinTracer
       # handle either a URI object (passed by Faraday v0.8.x in testing), or something string-izable
       url = env[:url].respond_to?(:host) ? env[:url] : URI.parse(env[:url].to_s)
       local_endpoint = ::Trace.default_endpoint # The rack middleware set this up for us.
-      remote_endpoint = callee_endpoint(url)  # The endpoint we are calling.
+      remote_endpoint = callee_endpoint(url) # The endpoint we are calling.
 
       response = nil
       begin
@@ -33,12 +33,12 @@ module ZipkinTracer
         end
         # annotate with method (GET/POST/etc.) and uri path
         ::Trace.set_rpc_name(env[:method].to_s.downcase)
-        record(::Trace::BinaryAnnotation.new("http.uri", url.path, "STRING", local_endpoint))
-        record(::Trace::BinaryAnnotation.new("sa", "1", "BOOL", remote_endpoint))
+        record(::Trace::BinaryAnnotation.new('http.uri', url.path, 'STRING', local_endpoint))
+        record(::Trace::BinaryAnnotation.new('sa', '1', 'BOOL', remote_endpoint))
         record(::Trace::Annotation.new(::Trace::Annotation::CLIENT_SEND, local_endpoint))
         response = @app.call(env).on_complete do |renv|
           # record HTTP status code on response
-          record(::Trace::BinaryAnnotation.new("http.status", renv[:status].to_s, "STRING", local_endpoint))
+          record(::Trace::BinaryAnnotation.new('http.status', renv[:status].to_s, 'STRING', local_endpoint))
         end
         record(::Trace::Annotation.new(::Trace::Annotation::CLIENT_RECV, local_endpoint))
       ensure

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 module ZipkinTracer
-  VERSION = "0.8.0"
+  VERSION = "0.8.1"
 end
 

--- a/spec/lib/faraday/zipkin-tracer_spec.rb
+++ b/spec/lib/faraday/zipkin-tracer_spec.rb
@@ -16,32 +16,31 @@ describe ZipkinTracer::FaradayHandler do
     end
   end
 
-  # Ruby 1.8 didn't support \h
-  HEX_REGEX = RUBY_VERSION >= "1.9.2" ? '\h' : '[0-9a-fA-F]'
+  HEX_REGEX = /\A\h{16}\z/
 
-  let(:response_env) { { :status => 200 } }
-  let(:wrapped_app) { lambda{|env| ResponseObject.new(env, response_env)} }
+  let(:response_env) { { status: 200 } }
+  let(:wrapped_app) { lambda { |env| ResponseObject.new(env, response_env) } }
 
   let(:hostname) { 'service.example.com' }
   let(:host_ip) { 0x11223344 }
   let(:url_path) { '/some/path/here' }
   let(:raw_url) { "https://#{hostname}#{url_path}" }
 
-  def process(body, url, headers={})
+  def process(body, url, headers = {})
     env = {
-      :method => :post,
-      :url => url,
-      :body => body,
-      :request_headers => Faraday::Utils::Headers.new(headers),
+      method: :post,
+      url: url,
+      body: body,
+      request_headers: Faraday::Utils::Headers.new(headers),
     }
     middleware.call(env)
   end
 
-  before(:each) {
+  before do
     ::Trace.sample_rate = 0.1 # make sure initialized
-    allow(::Trace).to receive(:default_endpoint)
+    allow(::Trace).to receive(:default_endpoint).and_return(::Trace::Endpoint.new('127.0.0.1', '80', service_name))
     allow(::Trace::Endpoint).to receive(:host_to_i32).with(hostname).and_return(host_ip)
-  }
+  end
 
   shared_examples 'can make requests' do
     # helper to check host component of annotation
@@ -54,24 +53,29 @@ describe ZipkinTracer::FaradayHandler do
     def expect_tracing
       # expect SEND then RECV
       expect(::Trace).to receive(:set_rpc_name).with('post')
-      expect(::Trace).to receive(:record).with(instance_of(::Trace::BinaryAnnotation)) do |ann|
+
+      expect(middleware).to receive(:record).with(instance_of(::Trace::BinaryAnnotation)) do |ann|
         expect(ann.key).to eq('http.uri')
         expect(ann.value).to eq(url_path)
       end
-      expect(::Trace).to receive(:record).with(instance_of(::Trace::BinaryAnnotation)) do |ann|
+
+      expect(middleware).to receive(:record).with(instance_of(::Trace::BinaryAnnotation)) do |ann|
         expect(ann.key).to eq('sa')
-        expect(ann.value).to eq(1)
+        expect(ann.value).to eq('1')
         expect_host(ann.host, host_ip, service_name)
       end
-      expect(::Trace).to receive(:record).with(instance_of(::Trace::BinaryAnnotation)) do |ann|
+
+      expect(middleware).to receive(:record).with(instance_of(::Trace::BinaryAnnotation)) do |ann|
         expect(ann.key).to eq('http.status')
-        expect(ann.value).to eq(200)
+        expect(ann.value).to eq('200')
       end
-      expect(::Trace).to receive(:record).with(instance_of(::Trace::Annotation)) do |ann|
+
+      expect(middleware).to receive(:record).with(instance_of(::Trace::Annotation)) do |ann|
         expect(ann.value).to eq(::Trace::Annotation::CLIENT_SEND)
         expect_host(ann.host, '127.0.0.1', service_name)
       end.ordered
-      expect(::Trace).to receive(:record).with(instance_of(::Trace::Annotation)) do |ann|
+
+      expect(middleware).to receive(:record).with(instance_of(::Trace::Annotation)) do |ann|
         expect(ann.value).to eq(::Trace::Annotation::CLIENT_RECV)
         expect_host(ann.host, '127.0.0.1', service_name)
       end.ordered
@@ -86,10 +90,11 @@ describe ZipkinTracer::FaradayHandler do
         ::Trace.push(trace_id) do
           result = process('', url).env
         end
+
         expect(result[:request_headers]['X-B3-TraceId']).to eq('0000000000000001')
         expect(result[:request_headers]['X-B3-ParentSpanId']).to eq('0000000000000003')
         expect(result[:request_headers]['X-B3-SpanId']).not_to eq('0000000000000003')
-        expect(result[:request_headers]['X-B3-SpanId']).to match(/^#{HEX_REGEX}{16}$/)
+        expect(result[:request_headers]['X-B3-SpanId']).to match(HEX_REGEX)
         expect(result[:request_headers]['X-B3-Sampled']).to eq('true')
         expect(result[:request_headers]['X-B3-Flags']).to eq('1')
       end
@@ -107,9 +112,9 @@ describe ZipkinTracer::FaradayHandler do
       it 'generates a new ID, and sets the X-B3 request headers' do
         expect_tracing
         result = process('', url).env
-        expect(result[:request_headers]['X-B3-TraceId']).to match(/^#{HEX_REGEX}{16}$/)
-        expect(result[:request_headers]['X-B3-ParentSpanId']).to match(/^#{HEX_REGEX}{16}$/)
-        expect(result[:request_headers]['X-B3-SpanId']).to match(/^#{HEX_REGEX}{16}$/)
+        expect(result[:request_headers]['X-B3-TraceId']).to match(HEX_REGEX)
+        expect(result[:request_headers]['X-B3-ParentSpanId']).to match(HEX_REGEX)
+        expect(result[:request_headers]['X-B3-SpanId']).to match(HEX_REGEX)
         expect(result[:request_headers]['X-B3-Sampled']).to match(/(true|false)/)
         expect(result[:request_headers]['X-B3-Flags']).to match(/(1|0)/)
       end


### PR DESCRIPTION
The caller service name is determined from the DOMAIN environment variable. Otherwise, it falls back to the default service name defined in the configuration file.

I also found that the specs in `/spec/lib/faraday/zipkin-tracer_spec.rb` file were not behaving properly. The checks inside the `expect(::Trace)` blocks were not actually being evaluated. Instead, they were silently failing and the specs would carry on and pass. I've changed them to use `expect(middleware)` instead.

Also, some minor updates to syntax, since I was touching the files anyways.

@jcarres-mdsol @jfeltesse-mdsol