### PR TITLE
Add a JSON tracer (ZipkinJsonTracer)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@
 
 # do not include Gemfile.lock in gem source
 Gemfile.lock
+
+.byebug_history

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: ruby
 rvm:
+- 2.2
 - 2.1
-- 1.9.3
-- jruby
-- jruby-1.7.21
+- 2.0
+- jruby-1.7.23
+- jruby-9.0.4.0
 deploy:
   provider: rubygems
   api_key:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.9.0
+Add a JSON tracer (ZipkinJsonTracer).
+
 # 0.8.1
 Set caller service name using domain environment variable. If the value
 is not set, it will fall back to the configuration file default.

--- a/README.md
+++ b/README.md
@@ -31,10 +31,13 @@ where Rails.config.zipkin_tracer or config is a hash that can contain the follow
  * `:whitelist_plugin` - plugin function which recieves Rack env and will force sampling if it returns true
  * `:zookeeper` - plugin function which uses zookeeper and kafka instead of scribe as the transport
  * `:logger` - A logger class following the standard's library Logger interface (Log4r, Rails.logger, etc).
+ * `:json_api_host` - hostname with protocol of a zipkin api instance (e.g. `https://zipkin.example.com`) to use JSON over HTTP instead of Scribe or Kafka
+ * `:traces_buffer` (default: 100) - the number of annotations stored until automatic flush
+   (note that annotations are also flushed when the request is complete)
 
 
- If The configuration do not provide a Scribe or a Zookeeper servers, then the middlewares will not
- attempt to send traces. But they will still generate proper IDs and pass them to other services.
+ If the configuration does not provide either a JSON, Scribe or Zookeeper server then the middlewares will not
+ attempt to send traces although they will still generate proper IDs and pass them to other services.
  Thus, if you only want to generate IDs for instance for logging and do not intent to integrate with Zipkin,
  you can still use this gem. Just do not specify any server :)
 
@@ -141,3 +144,11 @@ based broker discovery being JVM based.
 # Install scribe
   gem 'scribe', "~> 0.2.4"
 ```
+
+### JSON Tracer
+
+Like the other tracers, it inherits from the Tracer found in Finagle.
+If the configuration specifies a `json_api_host` then the gem will serialize the traces to JSON
+and POST them to the defined host (the path to which the data is posted is `/api/v1/spans`).
+If a `traces_buffer` value is provided it will buffer the traces call so as not to hammer your zipkin
+instance. The default is `10`.

--- a/lib/zipkin-tracer.rb
+++ b/lib/zipkin-tracer.rb
@@ -1,4 +1,5 @@
 require 'base64' #Bug in finagle. They should be requiring this: finagle-thrift-1.4.1/lib/finagle-thrift/tracer.rb:115
+require 'zipkin-tracer/trace'
 require 'zipkin-tracer/rack/zipkin-tracer'
 
 begin

--- a/lib/zipkin-tracer/careless_scribe.rb
+++ b/lib/zipkin-tracer/careless_scribe.rb
@@ -16,7 +16,7 @@ require 'sucker_punch'
 
 
 module ScribeThrift
-  # This is here just for the monkey partching
+  # This is here just for the monkey patching
   class Client
     # This method in the original class was both sending and receiving logs.
     # The original class: https://github.com/twitter/scribe/blob/master/vendor/gen-rb/scribe.rb
@@ -46,12 +46,10 @@ class AsyncScribe
   rescue ThriftClient::NoServersAvailable, Thrift::Exception
     # I couldn't care less
   end
-
 end
 
 # Scribe which rescue thrift errors to avoid them to raise to the client
 class CarelessScribe
-
   def initialize(scribe_server_address)
     @server_address = scribe_server_address
   end
@@ -66,5 +64,4 @@ class CarelessScribe
   rescue ThriftClient::NoServersAvailable, Thrift::Exception
     # I couldn't care less
   end
-
 end

--- a/lib/zipkin-tracer/trace.rb
+++ b/lib/zipkin-tracer/trace.rb
@@ -1,0 +1,67 @@
+require 'finagle-thrift'
+require 'finagle-thrift/trace'
+
+module Trace
+  class Span
+    def to_h
+      {
+        name: @name,
+        traceId: @span_id.trace_id.to_s,
+        id: @span_id.span_id.to_s,
+        parentId: @span_id.parent_id.nil? ? nil : @span_id.parent_id.to_s,
+        annotations: @annotations.map!(&:to_h),
+        binaryAnnotations: @binary_annotations.map!(&:to_h),
+        debug: @debug
+      }
+    end
+  end
+
+  class Annotation
+    def to_h
+      {
+        value: @value,
+        timestamp: @timestamp,
+        endpoint: host.to_h
+      }
+    end
+  end
+
+  class BinaryAnnotation
+    def to_h
+      {
+        key: @key,
+        value: @value,
+        endpoint: host.to_h
+      }
+    end
+  end
+
+  class Endpoint
+    LOCALHOST = '127.0.0.1'
+    LOCALHOST_I32 = 0x7f000001
+
+    attr_accessor :ip_format
+
+    # we cannot override the initializer to add an extra parameter so use a factory
+    def self.make_endpoint(hostname, service_port, service_name, ip_format)
+      ipv4 = begin
+        hostname ||= Socket.gethostname
+        ip_format == :string ? Socket.getaddrinfo(hostname, nil, :INET)[0][3] : host_to_i32(hostname)
+      rescue
+        ip_format == :string ? LOCALHOST : LOCALHOST_I32
+      end
+
+      ep = Endpoint.new(ipv4, service_port, service_name)
+      ep.ip_format = ip_format
+      ep
+    end
+
+    def to_h
+      {
+        ipv4: ipv4,
+        port: port,
+        serviceName: service_name
+      }
+    end
+  end
+end

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 module ZipkinTracer
-  VERSION = "0.8.1"
+  VERSION = "0.9.0"
 end
 

--- a/lib/zipkin-tracer/zipkin_json_tracer.rb
+++ b/lib/zipkin-tracer/zipkin_json_tracer.rb
@@ -1,0 +1,73 @@
+require 'json'
+require 'faraday'
+require 'finagle-thrift'
+require 'finagle-thrift/tracer'
+
+class AsyncJsonApiClient
+  include SuckerPunch::Job
+  SPANS_PATH = '/api/v1/spans'
+
+  def perform(json_api_host, spans)
+    resp = Faraday.new(json_api_host).post do |req|
+      req.url SPANS_PATH
+      req.headers['Content-Type'] = 'application/json'
+      req.body = JSON.generate(spans.map!(&:to_h))
+    end
+  rescue => e
+    SuckerPunch.logger.error(e)
+  end
+end
+
+module Trace
+  class ZipkinJsonTracer < Tracer
+    TRACER_CATEGORY = "zipkin".freeze
+
+    def initialize(json_api_host, traces_buffer)
+      @json_api_host = json_api_host
+      @traces_buffer = traces_buffer
+      reset
+    end
+
+    def record(id, annotation)
+      return unless id.sampled?
+      span = get_span_for_id(id)
+
+      case annotation
+      when BinaryAnnotation
+        span.binary_annotations << annotation
+      when Annotation
+        span.annotations << annotation
+      end
+
+      @count += 1
+      if @count >= @traces_buffer || (annotation.is_a?(Annotation) && annotation.value == Annotation::SERVER_SEND)
+        flush!
+      end
+    end
+
+    def set_rpc_name(id, name)
+      return unless id.sampled?
+      span = get_span_for_id(id)
+      span.name = name.to_s
+    end
+
+    private
+
+    def get_span_for_id(id)
+      key = id.span_id.to_s
+      @spans[key] ||= begin
+        Span.new("", id)
+      end
+    end
+
+    def reset
+      @count = 0
+      @spans = {}
+    end
+
+    def flush!
+      AsyncJsonApiClient.new.async.perform(@json_api_host, @spans.values.dup)
+      reset
+    end
+  end
+end

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -1,41 +1,25 @@
 require 'spec_helper'
-def using_scribe?
-  @scribe_server && defined?(::Scribe)
-end
-
-def using_kafka?
-  @zookeeper && RUBY_PLATFORM == 'java' && defined?(::Hermann)
-end
 
 module ZipkinTracer
   RSpec.describe Config do
-    [:service_name, :service_port, :scribe_server, :zookeeper, :sample_rate,
-     :scribe_max_buffer, :annotate_plugin, :filter_plugin, :whitelist_plugin,
-     :logger ].each do |method|
+    [:service_name, :service_port, :json_api_host, :traces_buffer,
+      :scribe_server, :zookeeper, :sample_rate, :scribe_max_buffer,
+      :annotate_plugin, :filter_plugin, :whitelist_plugin, :logger].each do |method|
       it "can set and read configuration values for #{method}" do
         value = rand(100)
-        config = Config.new(nil, {method => value})
+        config = Config.new(nil, { method => value })
         expect(config.send(method)).to eq(value)
       end
     end
 
-    it 'sets defaults for sample rate' do
+    it 'sets defaults' do
       config = Config.new(nil, {})
-      expect(config.sample_rate).to_not eq(nil)
-    end
-
-    it 'sets defaults for scribe_max_buffer' do
-      config = Config.new(nil, {})
-      expect(config.scribe_max_buffer).to_not eq(nil)
-    end
-
-    it 'sets defaults for service_port' do
-      config = Config.new(nil, {})
-      expect(config.service_port).to_not eq(nil)
+      [:traces_buffer,:sample_rate, :scribe_max_buffer, :service_port].each do |key|
+        expect(config.send(key)).to_not eq(nil)
+      end
     end
 
     describe 'logger' do
-
       it 'uses Rails logger if available' do
         logger = 'TrusmisLogger'
         object_double("Rails", logger: logger).as_stubbed_const
@@ -50,45 +34,53 @@ module ZipkinTracer
       end
     end
 
-
-    describe '#using_scribe?' do
-      it 'returns false if scribe server has not been set' do
+    describe '#adapter' do
+      it 'returns nil if no adapter has been set' do
         config = Config.new(nil, {})
-        expect(config.using_scribe?).to eq(false)
+        expect(config.adapter).to be_nil
       end
-      it 'returns false if Scribe is not in the project' do
-        hide_const('Scribe')
-        config = Config.new(nil, {scribe_server: 'http://server.yes.net'})
-        expect(config.using_scribe?).to eq(false)
-      end
-      it 'returns true if scribe server has been set' do
-        config = Config.new(nil, {scribe_server: 'http://server.yes.net'})
-        expect(config.using_scribe?).to eq(true)
-      end
-    end
 
-    def using_kafka?
-      @zookeeper && RUBY_PLATFORM == 'java' && defined?(::Hermann)
-    end
+      context 'json' do
+        it 'returns :json if the json api endpoint has been set' do
+          config = Config.new(nil, json_api_host: 'http://server.yes.net')
+          expect(config.adapter).to eq(:json)
+        end
+      end
 
-    describe '#using_kafka?' do
-      it 'returns false if zookeeper has not been set' do
-        config = Config.new(nil, {})
-        stub_const('Hermann', 'CoolGem')
-        stub_const('RUBY_PLATFORM', 'java')
-        expect(config.using_scribe?).to eq(false)
+      context 'scribe' do
+        it 'does not return :scribe if Scribe is not in the project' do
+          hide_const('Scribe')
+          config = Config.new(nil, scribe_server: 'http://server.yes.net')
+          expect(config.adapter).to be_nil
+        end
+
+        it 'returns :scribe if the scribe server has been set' do
+          require 'scribe'
+          config = Config.new(nil, scribe_server: 'http://server.yes.net')
+          expect(config.adapter).to eq(:scribe)
+        end
       end
-      it 'returns false if Hermann is not in the project' do
-        hide_const('Hermann')
-        stub_const('RUBY_PLATFORM', 'java')
-        config = Config.new(nil, {zookeeper: 'http://server.yes.net'})
-        expect(config.using_scribe?).to eq(false)
-      end
-      it 'returns true if zookeeper and herman are used in java' do
-        stub_const('Hermann', 'CoolGem')
-        stub_const('RUBY_PLATFORM', 'java')
-        config = Config.new(nil, {zookeeper: 'http://server.yes.net'})
-        expect(config.using_kafka?).to eq(true)
+
+      context 'kafka' do
+        before { stub_const('RUBY_PLATFORM', 'java') }
+
+        it 'does not return :kafka if zookeeper has not been set' do
+          config = Config.new(nil, {})
+          stub_const('Hermann', 'CoolGem')
+          expect(config.adapter).to be_nil
+        end
+
+        it 'does not return :kafka if Hermann is not in the project' do
+          hide_const('Hermann')
+          config = Config.new(nil, zookeeper: 'http://server.yes.net')
+          expect(config.adapter).to be_nil
+        end
+
+        it 'returns :kafka if zookeeper and Hermann are used in java' do
+          stub_const('Hermann', 'CoolGem')
+          config = Config.new(nil, zookeeper: 'http://server.yes.net')
+          expect(config.adapter).to eq(:kafka)
+        end
       end
     end
   end

--- a/spec/lib/faraday/zipkin-tracer_spec.rb
+++ b/spec/lib/faraday/zipkin-tracer_spec.rb
@@ -121,11 +121,11 @@ describe ZipkinTracer::FaradayHandler do
     end
 
     context 'when looking up hostname raises' do
-      let(:host_ip) { 0x00000000 } # expect stubbed 'null' IP
+      let(:host_ip) { 0x7f000001 } # expect stubbed 'null' IP
 
-      before(:each) {
+      before do
         allow(::Trace::Endpoint).to receive(:host_to_i32).with(hostname).and_raise(SocketError)
-      }
+      end
 
       it 'traces with stubbed endpoint address' do
         expect_tracing

--- a/spec/lib/rack/zipkin-tracer_spec.rb
+++ b/spec/lib/rack/zipkin-tracer_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 
 describe ZipkinTracer::RackHandler do
   def middleware(app, config={})
-    ZipkinTracer::RackHandler.new(app, config)
+    ZipkinTracer::RackHandler.new(app, { logger: Logger.new(nil) }.merge(config))
   end
 
   def mock_env(path = '/', params = {})
@@ -18,9 +18,9 @@ describe ZipkinTracer::RackHandler do
 
   # stub ip address lookup
   let(:host_ip) { 0x11223344 }
-  before(:each) {
+  before do
     allow(::Trace::Endpoint).to receive(:host_to_i32).and_return(host_ip)
-  }
+  end
 
 
   shared_examples_for 'traces the request' do
@@ -38,42 +38,54 @@ describe ZipkinTracer::RackHandler do
   end
 
   describe 'initializer' do
-    context 'configured to use kafka', platform: :java do
-      let(:zookeeper) { 'localhost:2181' }
-      let(:zipkinKafkaTracer) { double('ZipkinKafkaTracer') }
+    # see spec/lib/zipkin_kafka_tracer_spec.rb
+    if RUBY_PLATFORM == 'java'
+      context 'configured to use kafka', platform: :java do
+        let(:zookeeper) { 'localhost:2181' }
+        let(:zipkinKafkaTracer) { double('ZipkinKafkaTracer') }
 
-      it 'creates a zipkin kafka tracer' do
-        allow(::Trace::ZipkinKafkaTracer).to receive(:new) { zipkinKafkaTracer }
-        expect(::Trace).to receive(:tracer=).with(zipkinKafkaTracer)
-        expect(zipkinKafkaTracer).to receive(:connect)
-        middleware(app, zookeeper: zookeeper)
+        it 'creates a zipkin kafka tracer' do
+          allow(::Trace::ZipkinKafkaTracer).to receive(:new) { zipkinKafkaTracer }
+          expect(::Trace).to receive(:tracer=).with(zipkinKafkaTracer)
+          expect(zipkinKafkaTracer).to receive(:connect)
+          middleware(app, zookeeper: zookeeper)
+        end
+      end
+    end
+
+    context 'configured to use json' do
+      subject { middleware(app, json_api_host: 'fake_json_api_host') }
+      it_should_behave_like 'traces the request'
+
+      it 'creates a zipkin json tracer' do
+        expect(::Trace::ZipkinJsonTracer).to receive(:new)
+        middleware(app, json_api_host: 'fake_json_api_host')
       end
     end
 
     context 'configured to use scribe' do
-      subject { middleware(app, logger: Logger.new(nil), scribe_server: 'fake_scribe_server') }
+      subject { middleware(app, scribe_server: 'fake_scribe_server') }
       it_should_behave_like 'traces the request'
 
       it 'creates a zipkin scribe tracer' do
         expect(::Trace::ZipkinTracer).to receive(:new)
-        middleware(app, logger: Logger.new(nil), scribe_server: 'fake_scribe_server')
+        middleware(app, scribe_server: 'fake_scribe_server')
       end
     end
 
     context 'no transport configured' do
-      subject { middleware(app, logger: Logger.new(nil)) }
+      subject { middleware(app) }
       it_should_behave_like 'traces the request'
 
       it 'creates a null scribe tracer' do
         expect(::Trace::NullTracer).to receive(:new)
-        middleware(app, logger: Logger.new(nil))
+        middleware(app)
       end
     end
 
     describe 'sample rate initialization' do
       let(:sample_rate) { 0.42 }
-      subject { middleware(app, logger: Logger.new(nil), sample_rate: sample_rate) }
-
+      subject { middleware(app, sample_rate: sample_rate) }
       it 'sets the sample rate' do
         expect(::Trace).to receive(:sample_rate=).with(sample_rate)
         subject.call(mock_env)
@@ -86,7 +98,7 @@ describe ZipkinTracer::RackHandler do
       end
 
       it 'sets the trace endpoint service name to the default configuration file value' do
-        expect(::Trace::Endpoint).to receive(:new).with(anything, anything, 'zipkin-tester')
+        expect(::Trace::Endpoint).to receive(:make_endpoint).with(nil, anything, 'zipkin-tester', :i32)
         middleware(app, service_name: 'zipkin-tester')
       end
     end
@@ -97,15 +109,14 @@ describe ZipkinTracer::RackHandler do
       end
 
       it 'sets the trace endpoint service name to the environment variable value' do
-        expect(::Trace::Endpoint).to receive(:new).with(anything, anything, 'zipkin-env-var-tester')
+        expect(::Trace::Endpoint).to receive(:make_endpoint).with(nil, anything, 'zipkin-env-var-tester', :i32)
         middleware(app, service_name: 'zipkin-tester')
       end
     end
-
   end
 
   context 'Zipkin headers are passed to the middlewawre' do
-    subject { middleware(app, logger: Logger.new(nil)) }
+    subject { middleware(app) }
     let(:env) {mock_env(',', ZipkinTracer::RackHandler::B3_REQUIRED_HEADERS.map {|a| Hash[a, 1] }.inject(:merge))}
 
     it 'does not set the RPC method' do
@@ -115,12 +126,12 @@ describe ZipkinTracer::RackHandler do
   end
 
   context 'Using Rails' do
-    subject { middleware(app, logger: Logger.new(nil)) }
+    subject { middleware(app) }
 
     context 'accessing a valid URL of our service' do
       before do
         rails = double('Rails')
-        allow(rails).to receive_message_chain(:application, :routes, :recognize_path).and_return({controller: 'trusmis', action: 'new'})
+        allow(rails).to receive_message_chain(:application, :routes, :recognize_path).and_return(controller: 'trusmis', action: 'new')
         stub_const('Rails', rails)
       end
       it_should_behave_like 'traces the request'
@@ -149,7 +160,7 @@ describe ZipkinTracer::RackHandler do
   end
 
   context 'configured without plugins' do
-    subject { middleware(app, logger: Logger.new(nil)) }
+    subject { middleware(app) }
 
     it_should_behave_like 'traces the request'
 
@@ -169,7 +180,7 @@ describe ZipkinTracer::RackHandler do
         # non-deterministic results
         allow(::Trace).to receive(:should_sample?) { false }
         expect(::Trace).to receive(:push) do |trace_id|
-          expect(trace_id.sampled?).to be_falsy
+          expect(trace_id.sampled?).to be false
         end
         status, headers, body = subject.call(mock_env())
         # return expected status
@@ -178,7 +189,7 @@ describe ZipkinTracer::RackHandler do
 
       it 'always samples if debug flag is passed in header' do
         expect(::Trace).to receive(:push) do |trace_id|
-          expect(trace_id.sampled?).to be_truthy
+          expect(trace_id.sampled?).to be true
         end
         status, headers, body = subject.call(
           mock_env('/', 'HTTP_X_B3_FLAGS' => ::Trace::Flags::DEBUG.to_s))
@@ -216,7 +227,6 @@ describe ZipkinTracer::RackHandler do
     subject { middleware(app, filter_plugin: lambda { |env| true }) }
 
     it_should_behave_like 'traces the request'
-
   end
 
   context 'configured with filter plugin that allows none' do
@@ -237,7 +247,7 @@ describe ZipkinTracer::RackHandler do
 
       it 'samples the request' do
         expect(::Trace).to receive(:push) do |trace_id|
-          expect(trace_id.sampled?).to be_truthy
+          expect(trace_id.sampled?).to be true
         end
         expect(::Trace).to receive(:record).exactly(4).times # extra whitelisted annotation
         status, _, _ = subject.call(mock_env)
@@ -251,7 +261,7 @@ describe ZipkinTracer::RackHandler do
       it 'does not sample the request' do
         allow(::Trace).to receive(:should_sample?) { false }
         expect(::Trace).to receive(:push) do |trace_id|
-          expect(trace_id.sampled?).to be_falsey
+          expect(trace_id.sampled?).to be false
         end
         expect(::Trace).to receive(:record).exactly(3).times # normal annotations
         status, _, _ = subject.call(mock_env)

--- a/spec/lib/trace_spec.rb
+++ b/spec/lib/trace_spec.rb
@@ -1,0 +1,135 @@
+require 'spec_helper'
+
+describe Trace do
+  let(:dummy_endpoint) { Trace::Endpoint.new('127.0.0.1', 9411, 'DummyService') }
+
+  describe Trace::Span do
+    let(:span_id) { 'c3a555b04cf7e099' }
+    let(:parent_id) { 'f0e71086411b1445' }
+    let(:annotations) { [
+      Trace::Annotation.new(Trace::Annotation::SERVER_RECV, dummy_endpoint).to_h,
+      Trace::Annotation.new(Trace::Annotation::SERVER_SEND, dummy_endpoint).to_h
+    ] }
+    let(:span_without_parent) do
+      Trace::Span.new('get', Trace::TraceId.new(span_id, nil, span_id, true, Trace::Flags::EMPTY))
+    end
+    let(:span_with_parent) do
+      Trace::Span.new('get', Trace::TraceId.new(span_id, parent_id, span_id, true, Trace::Flags::EMPTY))
+    end
+
+    before do
+      [span_with_parent, span_without_parent].each do |span|
+        annotations.each { |a| span.annotations << a }
+      end
+    end
+
+    describe '#to_h' do
+      it 'returns a hash representation of a span' do
+        expected_hash = {
+          name: 'get',
+          traceId: span_id,
+          id: span_id,
+          parentId: nil,
+          annotations: annotations,
+          binaryAnnotations: [],
+          debug: false
+        }
+        expect(span_without_parent.to_h).to eq(expected_hash)
+        expect(span_with_parent.to_h).to eq(expected_hash.merge(parentId: parent_id))
+      end
+    end
+  end
+
+  describe Trace::Annotation do
+    let(:annotation) { Trace::Annotation.new(Trace::Annotation::SERVER_RECV, dummy_endpoint) }
+
+    describe '#to_h' do
+      before { Timecop.freeze(Time.utc(2016, 1, 16, 23, 45)) }
+
+      it 'returns a hash representation of an annotation' do
+        expect(annotation.to_h).to eq(
+          value: 'sr',
+          timestamp: 1452987900000000,
+          endpoint: dummy_endpoint.to_h
+        )
+      end
+    end
+  end
+
+  describe Trace::BinaryAnnotation do
+    let(:annotation) { Trace::BinaryAnnotation.new('http.uri', '/', 'STRING', dummy_endpoint) }
+
+    describe '#to_h' do
+      it 'returns a hash representation of a binary annotation' do
+        expect(annotation.to_h).to eq(
+          key: 'http.uri',
+          value: '/',
+          endpoint: dummy_endpoint.to_h
+        )
+      end
+    end
+  end
+
+  describe Trace::Endpoint do
+    describe '.make_endpoint' do
+      let(:service_name) { 'service name' }
+      let(:hostname) { 'z2.example.com' }
+
+      context 'host lookup success' do
+        before do
+          allow(Socket).to receive(:getaddrinfo).with('z1.example.com', nil, :INET).
+            and_return([['', '', '', '8.8.4.4']])
+          allow(Socket).to receive(:getaddrinfo).with('z2.example.com', nil, :INET).
+            and_return([['', '', '', '8.8.8.8']])
+          allow(Socket).to receive(:getaddrinfo).with('z2.example.com', nil).
+            and_return([['', '', '', '8.8.8.8']])
+        end
+
+        it 'translates a given hostname to an ipv4 as an i32' do
+          ep = ::Trace::Endpoint.make_endpoint(hostname, 80, service_name, :i32)
+          expect(ep.ipv4).to eq(0x8080808)
+          expect(ep.ip_format).to eq(:i32)
+        end
+
+        it 'translates a given hostname to an ipv4 as a string' do
+          ep = ::Trace::Endpoint.make_endpoint(hostname, 80, service_name, :string)
+          expect(ep.ipv4).to eq('8.8.8.8')
+          expect(ep.ip_format).to eq(:string)
+        end
+
+        it 'auto detects the hostname' do
+          allow(Socket).to receive(:gethostname).and_return('z1.example.com')
+          ep = ::Trace::Endpoint.make_endpoint(nil, 80, service_name, :string)
+          expect(ep.ipv4).to eq('8.8.4.4')
+          expect(ep.ip_format).to eq(:string)
+        end
+      end
+
+      context 'host lookup failure' do
+        before { allow(Socket).to receive(:gethostname).and_raise }
+
+        it 'falls back to localhost as an i32' do
+          ep = ::Trace::Endpoint.make_endpoint(hostname, 80, service_name, :i32)
+          expect(ep.ipv4).to eq(0x7f000001)
+          expect(ep.ip_format).to eq(:i32)
+        end
+
+        it 'falls back to 127.0.0.1' do
+          ep = ::Trace::Endpoint.make_endpoint(hostname, 80, service_name, :string)
+          expect(ep.ipv4).to eq('127.0.0.1')
+          expect(ep.ip_format).to eq(:string)
+        end
+      end
+    end
+
+    describe '#to_h' do
+      it 'returns a hash representation of an endpoint' do
+        expect(dummy_endpoint.to_h).to eq(
+          ipv4: '127.0.0.1',
+          port: 9411,
+          serviceName: 'DummyService'
+        )
+      end
+    end
+  end
+end

--- a/spec/lib/zipkin_json_tracer_spec.rb
+++ b/spec/lib/zipkin_json_tracer_spec.rb
@@ -1,0 +1,104 @@
+require 'spec_helper'
+
+describe Trace::ZipkinJsonTracer do
+  let(:span_id) { 'c3a555b04cf7e099' }
+  let(:parent_id) { 'f0e71086411b1445' }
+  let(:sampled) { true }
+  let(:trace_id) { Trace::TraceId.new(span_id, nil, span_id, sampled, Trace::Flags::EMPTY) }
+  let(:dummy_endpoint) { Trace::Endpoint.new('127.0.0.1', 9411, 'DummyService') }
+  let(:annotation) { Trace::Annotation.new(Trace::Annotation::SERVER_RECV, dummy_endpoint) }
+  let(:binary_annotation) { Trace::BinaryAnnotation.new('http.uri', '/', 'STRING', dummy_endpoint) }
+
+  let(:json_api_host) { 'http://json.example.com' }
+  let(:traces_buffer) { 1 }
+  let(:tracer) { described_class.new(json_api_host, traces_buffer) }
+
+  describe '#record' do
+    context 'not sampling' do
+      let(:sampled) { false }
+      it 'returns without doing anything' do
+        expect(tracer).to_not receive(:get_span_for_id)
+        tracer.record(trace_id, annotation)
+      end
+    end
+
+    context 'sampling' do
+      let(:nb_traces) { 3 }
+      let(:span_hash) { {
+        name: '',
+        traceId: span_id,
+        id: span_id,
+        parentId: nil,
+        annotations: [],
+        binaryAnnotations: [],
+        debug: false
+      } }
+      let(:dummy_binary_annotations) {
+        [ { key: 'http.uri', value: '/', endpoint: dummy_endpoint.to_h } ]
+      }
+      let(:dummy_annotations) {
+        [ { value: 'sr', timestamp: 1452987900000000, endpoint: dummy_endpoint.to_h } ]
+      }
+      let(:stub_post_request) do
+        lambda { |body|
+          stub_request(:post, json_api_host + AsyncJsonApiClient::SPANS_PATH).with(
+            headers: { 'Content-Type' => 'application/json' },
+            body: JSON.generate(body)
+          )
+        }
+      end
+
+      before { Timecop.freeze(Time.utc(2016, 1, 16, 23, 45)) }
+
+      context 'traces_buffer == 1 (no buffering)' do
+        before { expect(tracer).to receive(:flush!).exactly(nb_traces).times.and_call_original }
+
+        it 'records a binary annotation' do
+          stub_post_request.([span_hash.merge(binaryAnnotations: dummy_binary_annotations)])
+          nb_traces.times { tracer.record(trace_id, binary_annotation) }
+        end
+
+        it 'records an annotation' do
+          stub_post_request.([span_hash.merge(annotations: dummy_annotations)])
+          nb_traces.times { tracer.record(trace_id, annotation) }
+        end
+      end
+
+      context 'traces_buffer > 1' do
+        let(:traces_buffer) { 3 }
+        before { expect(tracer).to receive(:flush!).exactly(2).times.and_call_original }
+
+        it 'records several binary annotations' do
+          stub_post_request.([span_hash.merge(binaryAnnotations: dummy_binary_annotations * 3)])
+          (nb_traces * 2).times { tracer.record(trace_id, binary_annotation) }
+        end
+
+        it 'records several annotations' do
+          stub_post_request.([span_hash.merge(annotations: dummy_annotations * 3)])
+          (nb_traces * 2).times { tracer.record(trace_id, annotation) }
+        end
+      end
+    end
+  end
+
+  describe '#set_rpc_name' do
+    let(:rpc_name) { 'this_is_an_rpc' }
+
+    context 'not sampling' do
+      let(:sampled) { false }
+      it 'returns without doing anything' do
+        expect(tracer).to_not receive(:get_span_for_id)
+        tracer.set_rpc_name(trace_id, rpc_name)
+      end
+    end
+
+    context 'sampling' do
+      it 'sets the span name' do
+        span = Trace::Span.new('', trace_id)
+        allow(tracer).to receive(:get_span_for_id).and_return(span)
+        expect(span).to receive(:name=).with(rpc_name)
+        tracer.set_rpc_name(trace_id, rpc_name)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,14 @@
 require 'zipkin-tracer'
 require 'pry'
+require 'timecop'
+require 'webmock/rspec'
+require 'sucker_punch/testing/inline'
 
 RSpec.configure do |config|
   config.order = :random
+
+  config.after(:each) do
+    Timecop.return
+    WebMock.reset!
+  end
 end

--- a/zipkin-tracer.gemspec
+++ b/zipkin-tracer.gemspec
@@ -18,30 +18,33 @@ $:.unshift lib unless $:.include?(lib)
 require 'zipkin-tracer/version'
 
 Gem::Specification.new do |s|
-  s.name                      = "zipkin-tracer"
+  s.name                      = 'zipkin-tracer'
   s.version                   = ZipkinTracer::VERSION
-  s.authors                   = ["Franklin Hu", "R Tyler Croy", "James Way"]
-  s.email                     = ["franklin@twitter.com", 'tyler@monkeypox.org', 'jamescway@gmail.com']
+  s.authors                   = ['Franklin Hu', 'R Tyler Croy', 'James Way', 'Jordi Polo', 'Julien Feltesse', 'Scott Steeg']
+  s.email                     = ['franklin@twitter.com', 'tyler@monkeypox.org', 'jamescway@gmail.com', 'jcarres@mdsol.com', 'jfeltesse@mdsol.com', 'ssteeg@mdsol.com']
   s.homepage                  = 'https://github.com/openzipkin/zipkin-tracer'
-  s.summary                   = "Ruby tracing via Zipkin"
-  s.description               = "Adds tracing instrumentation for ruby applications"
+  s.summary                   = 'Ruby tracing via Zipkin'
+  s.description               = 'Adds tracing instrumentation for ruby applications'
 
-  s.required_rubygems_version = ">= 1.3.5"
+  s.required_rubygems_version = '>= 1.3.5'
 
-  s.files                     = Dir.glob("{bin,lib}/**/*")
+  s.files                     = Dir.glob('{bin,lib}/**/*')
   s.require_path              = 'lib'
 
-  s.add_dependency "finagle-thrift", "~> 1.4.1"
-  s.add_dependency "rack", "~> 1.3"
+  s.add_dependency 'finagle-thrift', '~> 1.4.1'
+  s.add_dependency 'rack', '~> 1.3'
   s.add_dependency 'sucker_punch', '~> 1.0'
 
-  s.add_development_dependency "rspec", "~> 3.3"
-  s.add_development_dependency "rack-test", "~> 0.6"
-  s.add_development_dependency "rake", '~> 10.0'
-  s.add_development_dependency "pry", '~> 0.10'
-  s.add_development_dependency "faraday", '~> 0.8'
+  s.add_development_dependency 'rspec', '~> 3.3'
+  s.add_development_dependency 'rack-test', '~> 0.6'
+  s.add_development_dependency 'rake', '~> 10.0'
+  s.add_development_dependency 'pry', '~> 0.10'
+  s.add_development_dependency 'faraday', '~> 0.8'
+  s.add_development_dependency 'timecop', '~> 0.8'
+  s.add_development_dependency 'webmock', '~> 1.22'
 
-  # install one or the other (Scribe or Hermann)
-  s.add_development_dependency 'hermann', "~> 0.25"
-  s.add_development_dependency "scribe", "~> 0.2.4"
+  # manually install the gem depending on the adapter you want to use
+  # multi_json might not be needed if your project already uses a JSON gem
+  s.add_development_dependency 'hermann', '~> 0.25'
+  s.add_development_dependency 'scribe', '~> 0.2.4'
 end


### PR DESCRIPTION
This adds a JSON tracer that sends traces in JSON over HTTP.

Noteworthy bits:
- the ip of the endpoint needs to be a regular string in standard ipv4 notation
- doing the actual JSON serializing in the separate thread so that the host application is not slowed down.
