### PR TITLE
Make Scribe actually an optional dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.9.1
+Make Scribe actually optional by inspecting the conf first and requiring after.
+
 # 0.9.0
 Add a JSON tracer (ZipkinJsonTracer).
 

--- a/README.md
+++ b/README.md
@@ -31,10 +31,6 @@ where `Rails.config.zipkin_tracer` or `config` is a hash that can contain the fo
 * `:whitelist_plugin` - plugin function which receives the Rack env and will force sampling if it returns true
 
 
-If the configuration does not provide either a JSON, Zookeeper or Scribe server then the middlewares will not attempt to send traces although they will still generate proper IDs and pass them to other services.
-Thus, if you only want to generate IDs for instance for logging and do not intent to integrate with Zipkin you can still use this gem. Just do not specify any server :)
-
-
 ### Sending traces on outgoing requests with Faraday
 
 First, Faraday has to be part of your Gemfile:
@@ -60,6 +56,7 @@ end
 
 Note that supplying the service name for the destination service is optional;
 the tracing will default to a service name derived from the first section of the destination URL (e.g. 'service.example.com' => 'service').
+
 
 ## Tracers
 
@@ -91,6 +88,13 @@ gem 'hermann', '~> 0.25'
 The original tracer, it uses scribe and thrift to send traces.
 
 You need to explicitly install the gem (`gem 'scribe', '~> 0.2.4'`) and set `:scribe_server` in the config.
+
+
+### Null
+
+If the configuration does not provide either a JSON, Zookeeper or Scribe server then the middlewares will not attempt to send traces although they will still generate proper IDs and pass them to other services.
+
+Thus, if you only want to generate IDs for instance for logging and do not intent to integrate with Zipkin you can still use this gem. Just do not specify any server :)
 
 
 

--- a/lib/zipkin-tracer/careless_scribe.rb
+++ b/lib/zipkin-tracer/careless_scribe.rb
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require 'scribe'
 require 'sucker_punch'
 
 

--- a/lib/zipkin-tracer/config.rb
+++ b/lib/zipkin-tracer/config.rb
@@ -25,9 +25,9 @@ module ZipkinTracer
     def adapter
       if !!@json_api_host
         :json
-      elsif !!(@scribe_server && defined?(::Scribe))
+      elsif !!@scribe_server
         :scribe
-      elsif !!(@zookeeper && RUBY_PLATFORM == 'java' && defined?(::Hermann))
+      elsif !!@zookeeper && RUBY_PLATFORM == 'java'
         :kafka
       else
         nil

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -12,6 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 module ZipkinTracer
-  VERSION = "0.9.0"
+  VERSION = "0.9.1"
 end
-

--- a/lib/zipkin-tracer/zipkin_json_tracer.rb
+++ b/lib/zipkin-tracer/zipkin_json_tracer.rb
@@ -1,6 +1,6 @@
 require 'json'
 require 'faraday'
-require 'finagle-thrift'
+require 'sucker_punch'
 require 'finagle-thrift/tracer'
 
 class AsyncJsonApiClient

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -48,12 +48,6 @@ module ZipkinTracer
       end
 
       context 'scribe' do
-        it 'does not return :scribe if Scribe is not in the project' do
-          hide_const('Scribe')
-          config = Config.new(nil, scribe_server: 'http://server.yes.net')
-          expect(config.adapter).to be_nil
-        end
-
         it 'returns :scribe if the scribe server has been set' do
           require 'scribe'
           config = Config.new(nil, scribe_server: 'http://server.yes.net')
@@ -67,12 +61,6 @@ module ZipkinTracer
         it 'does not return :kafka if zookeeper has not been set' do
           config = Config.new(nil, {})
           stub_const('Hermann', 'CoolGem')
-          expect(config.adapter).to be_nil
-        end
-
-        it 'does not return :kafka if Hermann is not in the project' do
-          hide_const('Hermann')
-          config = Config.new(nil, zookeeper: 'http://server.yes.net')
           expect(config.adapter).to be_nil
         end
 

--- a/spec/lib/zipkin_json_tracer_spec.rb
+++ b/spec/lib/zipkin_json_tracer_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'zipkin-tracer/zipkin_json_tracer'
 
 describe Trace::ZipkinJsonTracer do
   let(:span_id) { 'c3a555b04cf7e099' }

--- a/spec/lib/zipkin_kafka_tracer_spec.rb
+++ b/spec/lib/zipkin_kafka_tracer_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'zipkin-tracer/zipkin_kafka_tracer'
 
 # needed the if statement because rspec tags are broken
 if RUBY_PLATFORM == 'java'

--- a/zipkin-tracer.gemspec
+++ b/zipkin-tracer.gemspec
@@ -44,7 +44,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'webmock', '~> 1.22'
 
   # manually install the gem depending on the adapter you want to use
-  # multi_json might not be needed if your project already uses a JSON gem
   s.add_development_dependency 'hermann', '~> 0.25'
   s.add_development_dependency 'scribe', '~> 0.2.4'
 end


### PR DESCRIPTION
Up until now even if you used a different tracer (Kafka, JSON) you still needed to depend on Scribe because of the hard coded require at the top of the rack handler file.
This commit moves the require directives to the appropriate places so that we require only what we need.

@jcarres-mdsol @adriancole @ssteeg-mdsol @jamescway 