### PR TITLE
Force bundler 1.10.6 in TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,6 @@ deploy:
   on:
     tags: true
     repo: openzipkin/zipkin-tracer
+before_install:
+  - rvm @global do gem uninstall bundler -a -x
+  - rvm @global do gem install bundler -v 1.10.6


### PR DESCRIPTION
Version 1.11 has a bug preventing gems to be properly installed with jruby

Follow up from PR #33 

See https://github.com/travis-ci/travis-ci/issues/5290