### PR TITLE
DRY tracer classes

### DIFF
--- a/lib/zipkin-tracer/rack/zipkin-tracer.rb
+++ b/lib/zipkin-tracer/rack/zipkin-tracer.rb
@@ -33,7 +33,7 @@ module ZipkinTracer
       ::Trace.tracer = case adapter
         when :json
           require 'zipkin-tracer/zipkin_json_tracer'
-          ::Trace::ZipkinJsonTracer.new(config.json_api_host, config.traces_buffer)
+          ::Trace::ZipkinJsonTracer.new(json_api_host: config.json_api_host, traces_buffer: config.traces_buffer)
         when :scribe
           require 'zipkin-tracer/careless_scribe'
           ::Trace::ZipkinTracer.new(CarelessScribe.new(config.scribe_server), config.scribe_max_buffer)

--- a/lib/zipkin-tracer/rack/zipkin-tracer.rb
+++ b/lib/zipkin-tracer/rack/zipkin-tracer.rb
@@ -39,9 +39,7 @@ module ZipkinTracer
           ::Trace::ZipkinTracer.new(CarelessScribe.new(config.scribe_server), config.scribe_max_buffer)
         when :kafka
           require 'zipkin-tracer/zipkin_kafka_tracer'
-          kafkaTracer = ::Trace::ZipkinKafkaTracer.new
-          kafkaTracer.connect(config.zookeeper)
-          kafkaTracer
+          ::Trace::ZipkinKafkaTracer.new(zookeepers: config.zookeeper)
         else
           ::Trace::NullTracer.new
       end

--- a/lib/zipkin-tracer/zipkin_json_tracer.rb
+++ b/lib/zipkin-tracer/zipkin_json_tracer.rb
@@ -1,7 +1,6 @@
 require 'json'
-require 'faraday'
-require 'sucker_punch'
-require 'finagle-thrift/tracer'
+require 'zipkin-tracer/zipkin_tracer_base'
+
 
 class AsyncJsonApiClient
   include SuckerPunch::Job
@@ -19,55 +18,9 @@ class AsyncJsonApiClient
 end
 
 module Trace
-  class ZipkinJsonTracer < Tracer
-    TRACER_CATEGORY = "zipkin".freeze
-
-    def initialize(json_api_host, traces_buffer)
-      @json_api_host = json_api_host
-      @traces_buffer = traces_buffer
-      reset
-    end
-
-    def record(id, annotation)
-      return unless id.sampled?
-      span = get_span_for_id(id)
-
-      case annotation
-      when BinaryAnnotation
-        span.binary_annotations << annotation
-      when Annotation
-        span.annotations << annotation
-      end
-
-      @count += 1
-      if @count >= @traces_buffer || (annotation.is_a?(Annotation) && annotation.value == Annotation::SERVER_SEND)
-        flush!
-      end
-    end
-
-    def set_rpc_name(id, name)
-      return unless id.sampled?
-      span = get_span_for_id(id)
-      span.name = name.to_s
-    end
-
-    private
-
-    def get_span_for_id(id)
-      key = id.span_id.to_s
-      @spans[key] ||= begin
-        Span.new("", id)
-      end
-    end
-
-    def reset
-      @count = 0
-      @spans = {}
-    end
-
+  class ZipkinJsonTracer < ZipkinTracerBase
     def flush!
-      AsyncJsonApiClient.new.async.perform(@json_api_host, @spans.values.dup)
-      reset
+      AsyncJsonApiClient.new.async.perform(@options[:json_api_host], @spans.values.dup)
     end
   end
 end

--- a/lib/zipkin-tracer/zipkin_json_tracer.rb
+++ b/lib/zipkin-tracer/zipkin_json_tracer.rb
@@ -18,6 +18,8 @@ class AsyncJsonApiClient
 end
 
 module Trace
+  # This class sends information to the Zipkin API.
+  # The API accepts a JSON representation of a list of spans
   class ZipkinJsonTracer < ZipkinTracerBase
     def flush!
       AsyncJsonApiClient.new.async.perform(@options[:json_api_host], @spans.values.dup)

--- a/lib/zipkin-tracer/zipkin_kafka_tracer.rb
+++ b/lib/zipkin-tracer/zipkin_kafka_tracer.rb
@@ -2,17 +2,11 @@ require 'finagle-thrift'
 require 'finagle-thrift/tracer'
 require 'hermann/producer'
 require 'hermann/discovery/zookeeper'
+require 'zipkin-tracer/zipkin_tracer_base'
 
 module Trace
-  class ZipkinKafkaTracer < Tracer
-    TRACER_CATEGORY     = "zipkin".freeze
+  class ZipkinKafkaTracer < ZipkinTracerBase
     DEFAULT_KAFKA_TOPIC = "zipkin_kafka".freeze
-
-    def initialize(opts={})
-      @logger = opts[:logger]
-      @topic  = opts[:topic] || DEFAULT_KAFKA_TOPIC
-      reset
-    end
 
     # need to connect after initialization
     def connect(zookeepers)
@@ -20,46 +14,15 @@ module Trace
       @producer  = Hermann::Producer.new(nil, broker_ids)
     end
 
-    def record(id, annotation)
-      return unless id.sampled?
-      span = get_span_for_id(id)
-
-      case annotation
-      when BinaryAnnotation
-        span.binary_annotations << annotation
-      when Annotation
-        span.annotations << annotation
+    def flush!
+      topic = opts[:topic] || DEFAULT_KAFKA_TOPIC
+      messages = @spans.values.map do |span|
+        buf = ''
+        trans = Thrift::MemoryBufferTransport.new(buf)
+        oprot = Thrift::BinaryProtocol.new(trans)
+        span.to_thrift.write(oprot)
+        @producer.push(buf, :topic => topic).value!
       end
-
-      flush!
     end
-
-    def set_rpc_name(id, name)
-      return unless id.sampled?
-      span = get_span_for_id(id)
-      span.name = name.to_s
-    end
-
-    private
-      def reset
-        @spans = {}
-      end
-
-      def get_span_for_id(id)
-        key = id.span_id.to_s
-        @spans[key] ||= begin
-          Span.new("", id)
-        end
-      end
-
-      def flush!
-        messages = @spans.values.map do |span|
-          buf = ''
-          trans = Thrift::MemoryBufferTransport.new(buf)
-          oprot = Thrift::BinaryProtocol.new(trans)
-          span.to_thrift.write(oprot)
-          @producer.push(buf, :topic => @topic).value!
-        end
-      end
   end
 end

--- a/lib/zipkin-tracer/zipkin_tracer_base.rb
+++ b/lib/zipkin-tracer/zipkin_tracer_base.rb
@@ -3,10 +3,15 @@ require 'finagle-thrift'
 require 'finagle-thrift/tracer'
 
 module Trace
+  # This class is a base for tracers sending information to Zipkin.
+  # It knows about zipkin types of annotations and send traces when the server
+  # is done with its request
+  # Traces dealing with zipkin should inherit from this class and implement the
+  # flush! method which actually sends the information
   class ZipkinTracerBase < Tracer
     TRACER_CATEGORY = "zipkin".freeze
 
-    def initialize(options)
+    def initialize(options={})
       @traces_buffer = options[:traces_buffer] || raise(ArgumentError, 'A proper buffer must be setup for the Zipkin tracer')
       @options = options
       reset
@@ -37,15 +42,14 @@ module Trace
     end
 
     def flush!
+      raise "not implemented"
     end
 
     private
 
     def get_span_for_id(id)
       key = id.span_id.to_s
-      @spans[key] ||= begin
-        Span.new("", id)
-      end
+      @spans[key] ||= Span.new("", id)
     end
 
     def reset

--- a/lib/zipkin-tracer/zipkin_tracer_base.rb
+++ b/lib/zipkin-tracer/zipkin_tracer_base.rb
@@ -1,0 +1,56 @@
+require 'faraday'
+require 'finagle-thrift'
+require 'finagle-thrift/tracer'
+
+module Trace
+  class ZipkinTracerBase < Tracer
+    TRACER_CATEGORY = "zipkin".freeze
+
+    def initialize(options)
+      @traces_buffer = options[:traces_buffer] || raise(ArgumentError, 'A proper buffer must be setup for the Zipkin tracer')
+      @options = options
+      reset
+    end
+
+    def record(id, annotation)
+      return unless id.sampled?
+      span = get_span_for_id(id)
+
+      case annotation
+      when BinaryAnnotation
+        span.binary_annotations << annotation
+      when Annotation
+        span.annotations << annotation
+      end
+
+      @count += 1
+      if @count >= @traces_buffer || (annotation.is_a?(Annotation) && annotation.value == Annotation::SERVER_SEND)
+        flush!
+        reset
+      end
+    end
+
+    def set_rpc_name(id, name)
+      return unless id.sampled?
+      span = get_span_for_id(id)
+      span.name = name.to_s
+    end
+
+    def flush!
+    end
+
+    private
+
+    def get_span_for_id(id)
+      key = id.span_id.to_s
+      @spans[key] ||= begin
+        Span.new("", id)
+      end
+    end
+
+    def reset
+      @count = 0
+      @spans = {}
+    end
+  end
+end

--- a/spec/lib/rack/zipkin-tracer_spec.rb
+++ b/spec/lib/rack/zipkin-tracer_spec.rb
@@ -47,7 +47,6 @@ describe ZipkinTracer::RackHandler do
         it 'creates a zipkin kafka tracer' do
           allow(::Trace::ZipkinKafkaTracer).to receive(:new) { zipkinKafkaTracer }
           expect(::Trace).to receive(:tracer=).with(zipkinKafkaTracer)
-          expect(zipkinKafkaTracer).to receive(:connect)
           middleware(app, zookeeper: zookeeper)
         end
       end

--- a/spec/lib/zipkin_json_tracer_spec.rb
+++ b/spec/lib/zipkin_json_tracer_spec.rb
@@ -12,7 +12,7 @@ describe Trace::ZipkinJsonTracer do
 
   let(:json_api_host) { 'http://json.example.com' }
   let(:traces_buffer) { 1 }
-  let(:tracer) { described_class.new(json_api_host, traces_buffer) }
+  let(:tracer) { described_class.new(json_api_host: json_api_host, traces_buffer: traces_buffer) }
 
   describe '#record' do
     context 'not sampling' do

--- a/spec/lib/zipkin_kafka_tracer_spec.rb
+++ b/spec/lib/zipkin_kafka_tracer_spec.rb
@@ -6,49 +6,48 @@ if RUBY_PLATFORM == 'java'
   describe Trace::ZipkinKafkaTracer, :platform => :java do
     let(:id)   { double('id') }
     let(:span) { double('span') }
+    let(:tracer) { described_class.new }
+    let(:zookeepers) { 'localhost:2181'     }
+    let(:zk)         { double('broker_ids') }
+    let(:producer)   { double('producer')   }
+
+    before do
+      allow(Hermann::Discovery::Zookeeper).to receive(:new) { zk }
+      allow(zk).to receive(:get_brokers)
+      allow(Hermann::Producer).to receive(:new) { producer }
+    end
 
     describe '#initialize' do
       context 'with default settings' do
-        it 'has nil logger' do
-          expect(subject.instance_variable_get(:@logger)).to be nil
-        end
+
+
         it 'has default topic' do
-          expect(subject.instance_variable_get(:@topic)).to eq Trace::ZipkinKafkaTracer::DEFAULT_KAFKA_TOPIC
+          expect(tracer.instance_variable_get(:@topic)).to eq Trace::ZipkinKafkaTracer::DEFAULT_KAFKA_TOPIC
         end
         it 'initializes instance variables' do
-          expect(subject.instance_variable_get(:@spans)).to be_a(Hash)
-          expect(subject.instance_variable_get(:@spans).length).to eq 0
+          expect(tracer.instance_variable_get(:@spans)).to be_a(Hash)
+          expect(tracer.instance_variable_get(:@spans).length).to eq 0
+        end
+        it 'connects to zookeeper to create the producer' do
+          expect(tracer.instance_variable_get(:@producer)).to eq producer
         end
       end
 
       context 'with options' do
-        let(:logger) { double('logger') }
         let(:topic)  { 'topic' }
+        let(:traces_buffer) { 42 }
 
-        subject { described_class.new({:logger => logger, :topic => topic}) }
+        let(:tracer) { described_class.new({traces_buffer: traces_buffer, topic: topic}) }
 
-        it 'has logger' do
-          expect(subject.instance_variable_get(:@logger)).to be logger
-        end
         it 'has an optional topic' do
-          expect(subject.instance_variable_get(:@topic)).to eq topic
+          expect(tracer.instance_variable_get(:@topic)).to eq topic
+        end
+        it 'has an optional traces_buffer' do
+          expect(tracer.instance_variable_get(:@traces_buffer)).to eq traces_buffer
         end
       end
     end
 
-    describe '#connect' do
-      let(:zookeepers) { 'localhost:2181'     }
-      let(:zk)         { double('broker_ids') }
-      let(:producer)   { double('producer')   }
-
-      it 'connects to zookeeper to create the producer' do
-        allow(Hermann::Discovery::Zookeeper).to receive(:new) { zk }
-        allow(zk).to receive(:get_brokers)
-        allow(Hermann::Producer).to receive(:new) { producer }
-        subject.connect(zookeepers)
-        expect(subject.instance_variable_get(:@producer)).to eq producer
-      end
-    end
 
     describe '#record' do
       module MockTrace
@@ -65,24 +64,24 @@ if RUBY_PLATFORM == 'java'
 
       it 'returns if id already sampled' do
         allow(id).to receive(:sampled?) { false }
-        expect(subject).to_not receive(:get_span_for_id)
-        subject.record(id, annotation)
+        expect(tracer).to_not receive(:get_span_for_id)
+        tracer.record(id, annotation)
       end
 
       context 'processing annotation' do
         before do
           allow(id).to receive(:sampled?) { true }
-          allow(subject).to receive(:get_span_for_id) { span }
-          expect(subject).to receive(:flush!)
+          allow(tracer).to receive(:get_span_for_id) { span }
+          expect(tracer).to receive(:flush!)
         end
 
         it 'records a binary annotation' do
           expect(span).to receive(:binary_annotations) { [] }
-          subject.record(id, binary_annotation)
+          tracer.record(id, binary_annotation)
         end
         it 'records an annotation' do
           expect(span).to receive(:annotations) { [] }
-          subject.record(id, annotation)
+          tracer.record(id, annotation)
         end
       end
     end
@@ -92,15 +91,15 @@ if RUBY_PLATFORM == 'java'
 
       it 'returns if id already sampled' do
         allow(id).to receive(:sampled?) { false }
-        expect(subject).to_not receive(:get_span_for_id)
-        subject.set_rpc_name(id, name)
+        expect(tracer).to_not receive(:get_span_for_id)
+        tracer.set_rpc_name(id, name)
       end
 
       it 'sets the span name' do
         allow(id).to receive(:sampled?) { true }
-        allow(subject).to receive(:get_span_for_id) { span }
+        allow(tracer).to receive(:get_span_for_id) { span }
         expect(span).to receive(:name=).with(name)
-        subject.set_rpc_name(id, name)
+        tracer.set_rpc_name(id, name)
       end
     end
   end

--- a/spec/support/test_app_config.ru
+++ b/spec/support/test_app_config.ru
@@ -7,7 +7,7 @@ zipkin_tracer_config = {
   service_port: 9410,
   sample_rate: 1,
   traces_buffer: 1,
-  log_api_host: '127.0.0.1:9410'
+  json_api_host: '127.0.0.1:9410'
 }
 
 use ZipkinTracer::RackHandler, zipkin_tracer_config

--- a/spec/support/test_app_config.ru
+++ b/spec/support/test_app_config.ru
@@ -6,8 +6,8 @@ zipkin_tracer_config = {
   service_name: 'your service name here',
   service_port: 9410,
   sample_rate: 1,
-  scribe_max_buffer: 1,
-  scribe_server: '127.0.0.1:9410'
+  traces_buffer: 1,
+  log_api_host: '127.0.0.1:9410'
 }
 
 use ZipkinTracer::RackHandler, zipkin_tracer_config


### PR DESCRIPTION
@jfeltesse-mdsol  Tell me what you think

Moved jsontracer and kafkatracer to inherit from tracerbase. Makes things a tad simpler and save some duplication there. Deleted the connect method from Kafka which was no more than a weird initializer.
Also the integration spec uses the json configuration so we test that instead of scribe

I have not updated the changelog because this is just a refactor.