### PR TITLE
only create binaryannotations and annotations when we are sampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.10.1
+Performance optimization: Do not create tracing related objects in the Faraday middleware if we
+are not sampling.
+Fix benchmark Rake task so it uses the proper Faraday middlewares
+
 # 0.10.0
 Always create trace IDs even when the trace  will not be sent to zipkin (other parts of the app may use them).
 Bugfix: Tracer is now Threadsafe

--- a/lib/zipkin-tracer/faraday/zipkin-tracer.rb
+++ b/lib/zipkin-tracer/faraday/zipkin-tracer.rb
@@ -20,31 +20,47 @@ module ZipkinTracer
     end
 
     def call(env)
-      # handle either a URI object (passed by Faraday v0.8.x in testing), or something string-izable
-      url = env[:url].respond_to?(:host) ? env[:url] : URI.parse(env[:url].to_s)
-      local_endpoint = Trace.default_endpoint # The rack middleware set this up for us.
-      remote_endpoint = callee_endpoint(url, local_endpoint.ip_format) # The endpoint we are calling.
-      response = nil
       trace_id = Trace.id.next_id
       with_trace_id(trace_id) do
         B3_HEADERS.each do |method, header|
           env[:request_headers][header] = trace_id.send(method).to_s
         end
-        # annotate with method (GET/POST/etc.) and uri path
-        @tracer.set_rpc_name(trace_id, env[:method].to_s.downcase)
-        @tracer.record(trace_id, Trace::BinaryAnnotation.new('http.uri', url.path, 'STRING', local_endpoint))
-        @tracer.record(trace_id, Trace::BinaryAnnotation.new('sa', '1', 'BOOL', remote_endpoint))
-        @tracer.record(trace_id, Trace::Annotation.new(Trace::Annotation::CLIENT_SEND, local_endpoint))
-        response = @app.call(env).on_complete do |renv|
-          # record HTTP status code on response
-          @tracer.record(trace_id, Trace::BinaryAnnotation.new('http.status', renv[:status].to_s, 'STRING', local_endpoint))
+        if trace_id.sampled?
+          trace!(env, trace_id)
+        else
+          @app.call(env)
         end
-        @tracer.record(trace_id, Trace::Annotation.new(Trace::Annotation::CLIENT_RECV, local_endpoint))
       end
-      response
     end
 
     private
+    SERVER_ADDRESS = 'sa'
+    SERVER_ADDRESS_SPECIAL_VALUE = '1'
+    STRING_TYPE = 'STRING'
+    BOOLEAN_TYPE = 'BOOL'
+    URI_KEY = 'http.uri'
+    STATUS_KEY = 'http.status'
+    UNKNOWN_URL = 'unknown'
+
+
+    def trace!(env, trace_id)
+      response = nil
+      # handle either a URI object (passed by Faraday v0.8.x in testing), or something string-izable
+      url = env[:url].respond_to?(:host) ? env[:url] : URI.parse(env[:url].to_s)
+      local_endpoint = Trace.default_endpoint # The rack middleware set this up for us.
+      remote_endpoint = callee_endpoint(url, local_endpoint.ip_format) # The endpoint we are calling.
+      # annotate with method (GET/POST/etc.) and uri path
+      @tracer.set_rpc_name(trace_id, env[:method].to_s.downcase)
+      @tracer.record(trace_id, Trace::BinaryAnnotation.new(URI_KEY, url.path, STRING_TYPE, local_endpoint))
+      @tracer.record(trace_id, Trace::BinaryAnnotation.new(SERVER_ADDRESS, SERVER_ADDRESS_SPECIAL_VALUE, BOOLEAN_TYPE, remote_endpoint))
+      @tracer.record(trace_id, Trace::Annotation.new(Trace::Annotation::CLIENT_SEND, local_endpoint))
+      response = @app.call(env).on_complete do |renv|
+        # record HTTP status code on response
+        @tracer.record(trace_id, Trace::BinaryAnnotation.new(STATUS_KEY, renv[:status].to_s, STRING_TYPE, local_endpoint))
+      end
+      @tracer.record(trace_id, Trace::Annotation.new(Trace::Annotation::CLIENT_RECV, local_endpoint))
+      response
+    end
 
     def with_trace_id(trace_id, &block)
       Trace.push(trace_id)
@@ -54,7 +70,7 @@ module ZipkinTracer
     end
 
     def callee_endpoint(url, ip_format)
-      service_name = @service_name || url.host.split('.').first || 'unknown' # default to url-derived service name
+      service_name = @service_name || url.host.split('.').first || UNKNOWN_URL # default to url-derived service name
       Trace::Endpoint.make_endpoint(url.host, url.port, service_name, ip_format)
     end
   end

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 module ZipkinTracer
-  VERSION = "0.10.0"
+  VERSION = "0.10.1"
 end


### PR DESCRIPTION
Avoid doing any tracing related business if we are not sampling this request.
if the sampling rate is 1% we are creating annotation objects and doing some processing 99% of the time to just throw it away afterwards. This PRs aims at solving that and hopefully make tracing lighter to its users.

@jfeltesse-mdsol  @adriancole 