### PR TITLE
Add faraday dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.10.2
+Add faraday as a dependency
+
 # 0.10.1
 Performance optimization: Do not create tracing related objects in the Faraday middleware if we
 are not sampling.

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 module ZipkinTracer
-  VERSION = "0.10.1"
+  VERSION = "0.10.2"
 end

--- a/zipkin-tracer.gemspec
+++ b/zipkin-tracer.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |s|
   s.files                     = Dir.glob('{bin,lib}/**/*')
   s.require_path              = 'lib'
 
+  s.add_dependency 'faraday', '~> 0.8'
   s.add_dependency 'finagle-thrift', '~> 1.4.1'
   s.add_dependency 'rack', '~> 1.3'
   s.add_dependency 'sucker_punch', '~> 1.0'
@@ -38,7 +39,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '~> 3.3'
   s.add_development_dependency 'rack-test', '~> 0.6'
   s.add_development_dependency 'rake', '~> 10.0'
-  s.add_development_dependency 'faraday', '~> 0.8'
   s.add_development_dependency 'timecop', '~> 0.8'
   s.add_development_dependency 'webmock', '~> 1.22'
 


### PR DESCRIPTION
The base tracer class requires it, raising a LoadError if it's not part of the app's bundle.

Reproducing is easy, simply make a brand new app without including faraday in your Gemfile and try to run it, it will raise
```
lib/zipkin-tracer/zipkin_tracer_base.rb:1:in `require': cannot load such file -- faraday (LoadError)
```

@jcarres-mdsol @adriancole 