### PR TITLE
avoid depending on finagle-thrift and thrif if possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.10.3
+Avoid requiring finagle-thrift when possible to avoid a hard dependency on Thrift
+
 # 0.10.2
 Add faraday as a dependency
 

--- a/lib/zipkin-tracer/careless_scribe.rb
+++ b/lib/zipkin-tracer/careless_scribe.rb
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 require 'scribe'
+require 'finagle-thrift' #depends on the thift gem
 require 'sucker_punch'
-
 
 module ScribeThrift
   # This is here just for the monkey patching

--- a/lib/zipkin-tracer/faraday/zipkin-tracer.rb
+++ b/lib/zipkin-tracer/faraday/zipkin-tracer.rb
@@ -1,6 +1,6 @@
 require 'faraday'
-require 'finagle-thrift'
 require 'finagle-thrift/trace'
+require 'finagle-thrift/tracer'
 require 'uri'
 
 module ZipkinTracer

--- a/lib/zipkin-tracer/rack/zipkin-tracer.rb
+++ b/lib/zipkin-tracer/rack/zipkin-tracer.rb
@@ -11,8 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-require 'finagle-thrift'
 require 'finagle-thrift/trace'
+require 'finagle-thrift/tracer'
 require 'zipkin-tracer/config'
 require 'zipkin-tracer/tracer_factory'
 

--- a/lib/zipkin-tracer/trace.rb
+++ b/lib/zipkin-tracer/trace.rb
@@ -1,4 +1,3 @@
-require 'finagle-thrift'
 require 'finagle-thrift/trace'
 require 'zipkin-tracer/zipkin_tracer_base'
 

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 module ZipkinTracer
-  VERSION = "0.10.2"
+  VERSION = "0.10.3"
 end

--- a/lib/zipkin-tracer/zipkin_json_tracer.rb
+++ b/lib/zipkin-tracer/zipkin_json_tracer.rb
@@ -2,7 +2,6 @@ require 'json'
 require 'sucker_punch'
 require 'zipkin-tracer/zipkin_tracer_base'
 
-
 class AsyncJsonApiClient
   include SuckerPunch::Job
   SPANS_PATH = '/api/v1/spans'

--- a/lib/zipkin-tracer/zipkin_kafka_tracer.rb
+++ b/lib/zipkin-tracer/zipkin_kafka_tracer.rb
@@ -1,5 +1,3 @@
-require 'finagle-thrift'
-require 'finagle-thrift/tracer'
 require 'hermann/producer'
 require 'hermann/discovery/zookeeper'
 require 'zipkin-tracer/zipkin_tracer_base'

--- a/lib/zipkin-tracer/zipkin_tracer_base.rb
+++ b/lib/zipkin-tracer/zipkin_tracer_base.rb
@@ -1,5 +1,4 @@
 require 'faraday'
-require 'finagle-thrift'
 require 'finagle-thrift/tracer'
 
 module Trace


### PR DESCRIPTION
Turns out we were using a file which depends on thrift. Taking that out would make an app blow up at the missing dependency.
Making requires more specific so we only require thrift when using scribe, not if we use the json api

@jfeltesse-mdsol  @adriancole 