### PR TITLE
Add Local Tracing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.10.4
+Add local tracing
+
 # 0.10.3
 Avoid requiring finagle-thrift when possible to avoid a hard dependency on Thrift
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-# 0.11.1
-Add local tracing
+# 0.12.0
+Add local tracing, fix flushing, add timestamp and duration to span
 
 # 0.11.0
 Use local spans instead of thread-safe variables to improve performance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.11.1
+Add local tracing
+
 # 0.11.0
 Use local spans instead of thread-safe variables to improve performance
 Add new "with_new_span" method to the tracer api to allow creating

--- a/README.md
+++ b/README.md
@@ -58,6 +58,41 @@ Note that supplying the service name for the destination service is optional;
 the tracing will default to a service name derived from the first section of the destination URL (e.g. 'service.example.com' => 'service').
 
 
+### Local tracing
+
+`ZipkinTracer::TraceClient` provides API to record local traces in your application.
+
+Both examples below have the same result.
+
+Example 1:
+```ruby
+ZipkinTracer::TraceClient.trace do |ztc|
+  ztc.record_local_component 'Local Trace'
+  ztc.record_tag 'key', 'sample'
+  # target process
+end
+```
+
+Example 2:
+```ruby
+ztc = ZipkinTracer::TraceClient
+ztc.record 'Start: '
+ztc.record_local_component 'Local Trace'
+ztc.record_tag 'key', 'sample'
+# target process
+ztc.record 'End: '
+```
+
+`.trace` method accepts one optional parameter to show in annotation keys.
+```ruby
+# with parameter
+ZipkinTracer::TraceClient.trace('services') do   # => 'Start: services', 'End: services'
+
+# without parameter
+ZipkinTracer::TraceClient.trace do   # => 'Start: ', 'End: '
+```
+
+
 ## Tracers
 
 ### JSON

--- a/README.md
+++ b/README.md
@@ -60,36 +60,23 @@ the tracing will default to a service name derived from the first section of the
 
 ### Local tracing
 
-`ZipkinTracer::TraceClient` provides API to record local traces in your application.
+`ZipkinTracer::TraceClient` provides an API to record local traces in your application.
+It can be used to measure the performance of process, record value of variables, and so on.
 
-Both examples below have the same result.
+When `local_component_span` method is called, it creates a new span and provides the following methods to create annotations.
+* record(key) - annotation
+* record_tag(key, value) - binary annotation
+* record_local_component(value) - binary annotation for local component
 
-Example 1:
+
+Example:
 ```ruby
-ZipkinTracer::TraceClient.trace do |ztc|
-  ztc.record_local_component 'Local Trace'
+ZipkinTracer::TraceClient.local_component_span do |ztc|
+  ztc.record 'New Annotation'
   ztc.record_tag 'key', 'sample'
+  ztc.record_local_component 'Local Trace'
   # target process
 end
-```
-
-Example 2:
-```ruby
-ztc = ZipkinTracer::TraceClient
-ztc.record 'Start: '
-ztc.record_local_component 'Local Trace'
-ztc.record_tag 'key', 'sample'
-# target process
-ztc.record 'End: '
-```
-
-`.trace` method accepts one optional parameter to show in annotation keys.
-```ruby
-# with parameter
-ZipkinTracer::TraceClient.trace('services') do   # => 'Start: services', 'End: services'
-
-# without parameter
-ZipkinTracer::TraceClient.trace do   # => 'Start: ', 'End: '
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -63,18 +63,15 @@ the tracing will default to a service name derived from the first section of the
 `ZipkinTracer::TraceClient` provides an API to record local traces in your application.
 It can be used to measure the performance of process, record value of variables, and so on.
 
-When `local_component_span` method is called, it creates a new span and provides the following methods to create annotations.
+When `local_component_span` method is called, it creates a new span and a local component, and provides the following methods to create annotations.
 * record(key) - annotation
 * record_tag(key, value) - binary annotation
-* record_local_component(value) - binary annotation for local component
-
 
 Example:
 ```ruby
-ZipkinTracer::TraceClient.local_component_span do |ztc|
+ZipkinTracer::TraceClient.local_component_span('Local Trace') do |ztc|
   ztc.record 'New Annotation'
   ztc.record_tag 'key', 'sample'
-  ztc.record_local_component 'Local Trace'
   # target process
 end
 ```

--- a/lib/zipkin-tracer.rb
+++ b/lib/zipkin-tracer.rb
@@ -1,6 +1,7 @@
 require 'base64' #Bug in finagle. They should be requiring this: finagle-thrift-1.4.1/lib/finagle-thrift/tracer.rb:115
 require 'zipkin-tracer/trace'
 require 'zipkin-tracer/rack/zipkin-tracer'
+require 'zipkin-tracer/trace_client'
 
 begin
   require 'faraday'

--- a/lib/zipkin-tracer/trace.rb
+++ b/lib/zipkin-tracer/trace.rb
@@ -10,6 +10,7 @@ module Trace
 
   class Span
     attr_reader :size
+    attr_accessor :timestamp, :duration
 
     # We record information into spans, then we send these spans to zipkin
     def record(annotation)
@@ -31,6 +32,8 @@ module Trace
         parentId: @span_id.parent_id.nil? ? nil : @span_id.parent_id.to_s,
         annotations: @annotations.map!(&:to_h),
         binaryAnnotations: @binary_annotations.map!(&:to_h),
+        timestamp: timestamp,
+        duration: duration,
         debug: @debug
       }
     end

--- a/lib/zipkin-tracer/trace_client.rb
+++ b/lib/zipkin-tracer/trace_client.rb
@@ -1,0 +1,26 @@
+module ZipkinTracer
+  class TraceClient
+    LOCAL_COMPONENT = 'lc'.freeze
+    STRING_TYPE = 'STRING'.freeze
+
+    def self.record(key)
+      Trace.record(Trace::Annotation.new(key, Trace.default_endpoint))
+    end
+
+    def self.record_tag(key, value)
+      Trace.record(Trace::BinaryAnnotation.new(key, value, STRING_TYPE, Trace.default_endpoint))
+    end
+
+    def self.record_local_component(value)
+      record_tag(LOCAL_COMPONENT, value)
+    end
+
+    def self.trace(key = nil)
+      if block_given?
+        record "Start: #{key}"
+        yield self
+        record "End: #{key}"
+      end
+    end
+  end
+end

--- a/lib/zipkin-tracer/trace_client.rb
+++ b/lib/zipkin-tracer/trace_client.rb
@@ -3,23 +3,27 @@ module ZipkinTracer
     LOCAL_COMPONENT = 'lc'.freeze
     STRING_TYPE = 'STRING'.freeze
 
-    def self.local_component_span(&block)
-      self.new(LOCAL_COMPONENT, &block) if block_given?
+    def self.local_component_span(local_component_value, &block)
+      if block_given?
+        client = self.new(LOCAL_COMPONENT, &block)
+        client.record_local_component local_component_value
+      end
     end
 
     def initialize(name, &block)
-      Trace.tracer.with_new_span(Trace.id, name) do |span|
+      @trace_id = Trace.id.next_id
+      Trace.tracer.with_new_span(@trace_id, name) do |span|
         @span = span
         block.call(self)
       end
     end
 
     def record(key)
-      @span.record(Trace::Annotation.new(key, Trace.default_endpoint))
+      @span.record(Trace::Annotation.new(key, Trace.default_endpoint)) if @trace_id.sampled?
     end
 
     def record_tag(key, value)
-      @span.record(Trace::BinaryAnnotation.new(key, value, STRING_TYPE, Trace.default_endpoint))
+      @span.record(Trace::BinaryAnnotation.new(key, value, STRING_TYPE, Trace.default_endpoint)) if @trace_id.sampled?
     end
 
     def record_local_component(value)

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 module ZipkinTracer
-  VERSION = "0.10.3"
+  VERSION = "0.10.4"
 end

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 module ZipkinTracer
-  VERSION = "0.11.1"
+  VERSION = "0.12.0"
 end

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 module ZipkinTracer
-  VERSION = "0.11.0"
+  VERSION = "0.11.1"
 end

--- a/lib/zipkin-tracer/zipkin_tracer_base.rb
+++ b/lib/zipkin-tracer/zipkin_tracer_base.rb
@@ -17,10 +17,10 @@ module Trace
 
     def with_new_span(trace_id, name)
       span = start_span(trace_id, name)
-      time_now = Time.now
-      span.timestamp = (time_now.to_f * 1_000_000).to_i # to microseconds
+      start_time = Time.now
+      span.timestamp = to_microseconds(start_time)
       result = yield span
-      span.duration = ((Time.now - time_now) * 1_000_000).to_i # to microseconds
+      span.duration = to_microseconds(Time.now - start_time)
       may_flush(span)
       result
     end
@@ -56,6 +56,10 @@ module Trace
 
     def reset
       Thread.current[:zipkin_spans] = {}
+    end
+
+    def to_microseconds(time)
+      (time.to_f * 1_000_000).to_i
     end
   end
 end

--- a/lib/zipkin-tracer/zipkin_tracer_base.rb
+++ b/lib/zipkin-tracer/zipkin_tracer_base.rb
@@ -27,7 +27,7 @@ module Trace
 
     def may_flush(span)
       size = spans.values.map(&:size).inject(:+) || 0
-      if size >= @traces_buffer || span.annotations.any?{ |ann| ann == Annotation::SERVER_SEND }
+      if size >= @traces_buffer || span.annotations.any?{ |ann| ann.value == Annotation::SERVER_SEND }
         flush!
         reset
       end

--- a/lib/zipkin-tracer/zipkin_tracer_base.rb
+++ b/lib/zipkin-tracer/zipkin_tracer_base.rb
@@ -17,7 +17,10 @@ module Trace
 
     def with_new_span(trace_id, name)
       span = start_span(trace_id, name)
+      time_now = Time.now
+      span.timestamp = (time_now.to_f * 1_000_000).to_i # to microseconds
       result = yield span
+      span.duration = ((Time.now - time_now) * 1_000_000).to_i # to microseconds
       may_flush(span)
       result
     end

--- a/spec/lib/faraday/zipkin-tracer_spec.rb
+++ b/spec/lib/faraday/zipkin-tracer_spec.rb
@@ -27,6 +27,7 @@ describe ZipkinTracer::FaradayHandler do
   let(:url_path) { '/some/path/here' }
   let(:raw_url) { "https://#{hostname}#{url_path}" }
   let(:tracer) { Trace.tracer }
+  let(:trace_id) { ::Trace::TraceId.new(1, 2, 3, true, ::Trace::Flags::DEBUG) }
 
   def process(body, url, headers = {})
     env = {
@@ -40,6 +41,7 @@ describe ZipkinTracer::FaradayHandler do
 
   before do
     Trace.tracer = Trace::NullTracer.new
+    Trace.push(trace_id)
     ::Trace.sample_rate = 1 # make sure initialized
     allow(::Trace).to receive(:default_endpoint).and_return(::Trace::Endpoint.new('127.0.0.1', '80', service_name))
     allow(::Trace::Endpoint).to receive(:host_to_i32).with(hostname).and_return(host_ip)

--- a/spec/lib/trace_client_spec.rb
+++ b/spec/lib/trace_client_spec.rb
@@ -108,6 +108,3 @@ describe ZipkinTracer::TraceClient do
     end
   end
 end
-
-
-

--- a/spec/lib/trace_client_spec.rb
+++ b/spec/lib/trace_client_spec.rb
@@ -1,50 +1,81 @@
 require 'spec_helper'
+require 'zipkin-tracer/zipkin_null_tracer'
 
-module ZipkinTracer
-  describe TraceClient do
-    let(:key) { 'key' }
-    let(:value) { 'value' }
-    subject { TraceClient }
+describe ZipkinTracer::TraceClient do
+  let(:name) { 'name' }
+  let(:key) { 'key' }
+  let(:value) { 'value' }
+  subject { ZipkinTracer::TraceClient }
 
-    before do
-      allow(Trace).to receive(:default_endpoint).and_return(Trace::Endpoint.new('127.0.0.1', '80', 'service_name'))
+  before do
+    Trace.tracer = Trace::NullTracer.new
+    allow(Trace).to receive(:default_endpoint).and_return(Trace::Endpoint.new('127.0.0.1', '80', 'service_name'))
+  end
+
+  def expect_new_span
+    expect(Trace.tracer).to receive(:with_new_span).with(anything, 'lc').and_call_original
+  end
+
+  describe '.record' do
+    it 'records an annotation' do
+      expect_new_span
+
+      expect_any_instance_of(Trace::Span).to receive(:record).with(instance_of(Trace::Annotation)) do |_, ann|
+        expect(ann.value).to eq('value')
+      end
+
+      subject.local_component_span do |ztc|
+        ztc.record(value)
+      end
     end
+  end
 
-    describe '.record' do
-      it 'records an annotation' do
-        expect(Trace).to receive(:record).with(instance_of(Trace::Annotation))
-        subject.record(key)
+  describe '.record_tag' do
+    it 'records a binary annotation' do
+      expect_new_span
+
+      expect_any_instance_of(Trace::Span).to receive(:record).with(instance_of(Trace::BinaryAnnotation)) do |_, ann|
+        expect(ann.key).to eq('key')
+        expect(ann.value).to eq('value')
+      end
+
+      subject.local_component_span do |ztc|
+        ztc.record_tag(key, value)
+      end
+    end
+  end
+
+  describe '.record_local_component' do
+    it 'records a binary annotation ' do
+      expect_new_span
+
+      expect_any_instance_of(Trace::Span).to receive(:record).with(instance_of(Trace::BinaryAnnotation)) do |_, ann|
+        expect(ann.key).to eq('lc')
+        expect(ann.value).to eq('value')
+      end
+
+      subject.local_component_span do |ztc|
+        ztc.record_local_component(value)
+      end
+    end
+  end
+
+  describe '.trace' do
+    context 'called with block' do
+      it 'creates new span' do
+        expect_new_span
+        subject.local_component_span {}
       end
     end
 
-    describe '.record_tag' do
-      it 'records a binary annotation' do
-        expect(Trace).to receive(:record).with(instance_of(Trace::BinaryAnnotation))
-        subject.record_tag(key, value)
-      end
-    end
-
-    describe '.record_local_component' do
-      it 'records a binary annotation ' do
-        expect(Trace).to receive(:record).with(instance_of(Trace::BinaryAnnotation))
-        subject.record_local_component(key)
-      end
-    end
-
-    describe '.trace' do
-      context 'called with block' do
-        it 'records two binary annotations' do
-          expect(Trace).to receive(:record).with(instance_of(Trace::Annotation)).exactly(2).times
-          subject.trace {}
-        end
-      end
-
-      context 'called without block' do
-        it 'records no annotations' do
-          expect(Trace).not_to receive(:record)
-          subject.trace
-        end
+    context 'called without block' do
+      it 'creates no span' do
+        expect(Trace.tracer).not_to receive(:with_new_span)
+        subject.local_component_span
       end
     end
   end
 end
+
+
+

--- a/spec/lib/trace_client_spec.rb
+++ b/spec/lib/trace_client_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+module ZipkinTracer
+  describe TraceClient do
+    let(:key) { 'key' }
+    let(:value) { 'value' }
+    subject { TraceClient }
+
+    before do
+      allow(Trace).to receive(:default_endpoint).and_return(Trace::Endpoint.new('127.0.0.1', '80', 'service_name'))
+    end
+
+    describe '.record' do
+      it 'records an annotation' do
+        expect(Trace).to receive(:record).with(instance_of(Trace::Annotation))
+        subject.record(key)
+      end
+    end
+
+    describe '.record_tag' do
+      it 'records a binary annotation' do
+        expect(Trace).to receive(:record).with(instance_of(Trace::BinaryAnnotation))
+        subject.record_tag(key, value)
+      end
+    end
+
+    describe '.record_local_component' do
+      it 'records a binary annotation ' do
+        expect(Trace).to receive(:record).with(instance_of(Trace::BinaryAnnotation))
+        subject.record_local_component(key)
+      end
+    end
+
+    describe '.trace' do
+      context 'called with block' do
+        it 'records two binary annotations' do
+          expect(Trace).to receive(:record).with(instance_of(Trace::Annotation)).exactly(2).times
+          subject.trace {}
+        end
+      end
+
+      context 'called without block' do
+        it 'records no annotations' do
+          expect(Trace).not_to receive(:record)
+          subject.trace
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/trace_client_spec.rb
+++ b/spec/lib/trace_client_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'zipkin-tracer/zipkin_null_tracer'
 
 describe ZipkinTracer::TraceClient do
-  let(:name) { 'name' }
+  let(:lc_value) { 'lc_value' }
   let(:key) { 'key' }
   let(:value) { 'value' }
   subject { ZipkinTracer::TraceClient }
@@ -10,13 +10,21 @@ describe ZipkinTracer::TraceClient do
   before do
     Trace.tracer = Trace::NullTracer.new
     allow(Trace).to receive(:default_endpoint).and_return(Trace::Endpoint.new('127.0.0.1', '80', 'service_name'))
+    allow(Trace.id).to receive(:next_id).and_return(Trace::TraceId.new(1, 2, 3, true, ::Trace::Flags::DEBUG))
   end
 
   def expect_new_span
-    expect(Trace.tracer).to receive(:with_new_span).with(anything, 'lc').and_call_original
+    expect(Trace.tracer).to receive(:with_new_span).ordered.with(anything, 'lc').and_call_original
   end
 
-  describe '.record' do
+  def expect_local_componant
+    expect_any_instance_of(Trace::Span).to receive(:record).with(instance_of(Trace::BinaryAnnotation)) do |_, ann|
+      expect(ann.key).to eq('lc')
+      expect(ann.value).to eq(lc_value)
+    end
+  end
+
+  describe '#record' do
     it 'records an annotation' do
       expect_new_span
 
@@ -24,13 +32,15 @@ describe ZipkinTracer::TraceClient do
         expect(ann.value).to eq('value')
       end
 
-      subject.local_component_span do |ztc|
+      expect_local_componant
+
+      subject.local_component_span(lc_value) do |ztc|
         ztc.record(value)
       end
     end
   end
 
-  describe '.record_tag' do
+  describe '#record_tag' do
     it 'records a binary annotation' do
       expect_new_span
 
@@ -39,13 +49,15 @@ describe ZipkinTracer::TraceClient do
         expect(ann.value).to eq('value')
       end
 
-      subject.local_component_span do |ztc|
+      expect_local_componant
+
+      subject.local_component_span(lc_value) do |ztc|
         ztc.record_tag(key, value)
       end
     end
   end
 
-  describe '.record_local_component' do
+  describe '#record_local_component' do
     it 'records a binary annotation ' do
       expect_new_span
 
@@ -54,24 +66,44 @@ describe ZipkinTracer::TraceClient do
         expect(ann.value).to eq('value')
       end
 
-      subject.local_component_span do |ztc|
+      expect_local_componant
+
+      subject.local_component_span(lc_value) do |ztc|
         ztc.record_local_component(value)
       end
     end
   end
 
-  describe '.trace' do
+  describe '.local_component_span' do
     context 'called with block' do
       it 'creates new span' do
         expect_new_span
-        subject.local_component_span {}
+        expect_local_componant
+
+        subject.local_component_span(lc_value) {}
       end
     end
 
     context 'called without block' do
       it 'creates no span' do
         expect(Trace.tracer).not_to receive(:with_new_span)
-        subject.local_component_span
+        subject.local_component_span(lc_value)
+      end
+    end
+  end
+
+  describe 'Trace has not been sampled' do
+    before do
+      allow(Trace.id).to receive(:next_id).and_return(Trace::TraceId.new(1, 2, 3, false, 0))
+    end
+
+    it 'does not record annotations' do
+      expect_new_span
+
+      expect_any_instance_of(Trace::Span).not_to receive(:record)
+
+      subject.local_component_span(lc_value) do |ztc|
+        ztc.record(value)
       end
     end
   end

--- a/spec/lib/trace_spec.rb
+++ b/spec/lib/trace_spec.rb
@@ -16,10 +16,15 @@ describe Trace do
     let(:span_with_parent) do
       Trace::Span.new('get', Trace::TraceId.new(span_id, parent_id, span_id, true, Trace::Flags::EMPTY))
     end
+    let(:timestamp) { 1452987900000000 }
+    let(:duration) { 100000 }
 
     before do
       [span_with_parent, span_without_parent].each do |span|
         annotations.each { |a| span.annotations << a }
+
+        span.timestamp = timestamp
+        span.duration = duration
       end
     end
 
@@ -32,7 +37,9 @@ describe Trace do
           parentId: nil,
           annotations: annotations,
           binaryAnnotations: [],
-          debug: false
+          debug: false,
+          timestamp: timestamp,
+          duration: duration
         }
         expect(span_without_parent.to_h).to eq(expected_hash)
         expect(span_with_parent.to_h).to eq(expected_hash.merge(parentId: parent_id))

--- a/spec/lib/zipkin_json_tracer_spec.rb
+++ b/spec/lib/zipkin_json_tracer_spec.rb
@@ -28,6 +28,8 @@ describe Trace::ZipkinJsonTracer do
         parentId: nil,
         annotations: [],
         binaryAnnotations: [],
+        timestamp: 1452987900000000,
+        duration: 0,
         debug: false
       } }
       let(:dummy_binary_annotations) {


### PR DESCRIPTION
Implement local trace for Zipkin.
I use "record_tag" for the method name to record binary annotation.

Specs and documents are also updated.
Please review.

@jfeltesse-mdsol @jcarres-mdsol @cabbott @ssteeg-mdsol 