### PR TITLE
use spans instead of tracers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.11.0
+Use local spans instead of thread-safe variables to improve performance
+Add new "with_new_span" method to the tracer api to allow creating
+custom spans
+
 # 0.10.3
 Avoid requiring finagle-thrift when possible to avoid a hard dependency on Thrift
 

--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,5 @@ gemspec
 platform :ruby do
   gem 'benchmark-ips'
   gem 'rbtrace'
+  gem 'byebug'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -93,7 +93,7 @@ end
 desc "Runs a zipkin middleware once."
 task :run_once do
   empty_app = EmptyMiddleware.new(nil)
-  app = FaradayMiddleware.new(nil)
+  app = FaradayMiddleware.new
 
   logger = Logger.new(Tempfile.new('fakelog'))
   null_configuration = { logger: logger, sample_rate: 1}
@@ -113,7 +113,7 @@ task :benchmark do
 
   empty_app = EmptyMiddleware.new(nil)
 
-  null_configuration = { logger: logger, sample_rate: 1}
+  null_configuration = { sample_rate: 1 }
   json_configuration = null_configuration.merge({ json_api_host: fake_url })
   scribe_configuration = null_configuration.merge({ scribe_server: fake_url })
 

--- a/lib/zipkin-tracer/trace.rb
+++ b/lib/zipkin-tracer/trace.rb
@@ -9,6 +9,20 @@ module Trace
   end
 
   class Span
+    attr_reader :size
+
+    # We record information into spans, then we send these spans to zipkin
+    def record(annotation)
+      @size ||= 0
+      case annotation
+      when BinaryAnnotation
+        binary_annotations << annotation
+      when Annotation
+        annotations << annotation
+      end
+      @size = @size + 1
+    end
+
     def to_h
       {
         name: @name,

--- a/lib/zipkin-tracer/tracer_factory.rb
+++ b/lib/zipkin-tracer/tracer_factory.rb
@@ -1,4 +1,3 @@
-
 module ZipkinTracer
   class TracerFactory
     def tracer(config)
@@ -10,12 +9,13 @@ module ZipkinTracer
           options = { json_api_host: config.json_api_host, traces_buffer: config.traces_buffer, logger: config.logger }
           Trace::ZipkinJsonTracer.new(options)
         when :scribe
-          require 'zipkin-tracer/careless_scribe'
-          Trace::ZipkinTracer.new(CarelessScribe.new(config.scribe_server), config.scribe_max_buffer)
+          require 'zipkin-tracer/zipkin_scribe_tracer'
+          Trace::ScribeTracer.new(scribe_server: config.scribe_server, traces_buffer: config.scribe_max_buffer)
         when :kafka
           require 'zipkin-tracer/zipkin_kafka_tracer'
           Trace::ZipkinKafkaTracer.new(zookeepers: config.zookeeper)
         else
+          require 'zipkin-tracer/zipkin_null_tracer'
           Trace::NullTracer.new
       end
       Trace.tracer = tracer

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 module ZipkinTracer
-  VERSION = "0.10.3"
+  VERSION = "0.11.0"
 end

--- a/lib/zipkin-tracer/zipkin_null_tracer.rb
+++ b/lib/zipkin-tracer/zipkin_null_tracer.rb
@@ -1,0 +1,11 @@
+module Trace
+  # Monkey patching Nulltracer from thrift.
+  # All our tracers have a start_span method, adding it to
+  # the NullTracer also.
+  class NullTracer
+    def with_new_span(trace_id, name)
+      span = Span.new(name, trace_id)
+      yield span
+    end
+  end
+end

--- a/lib/zipkin-tracer/zipkin_scribe_tracer.rb
+++ b/lib/zipkin-tracer/zipkin_scribe_tracer.rb
@@ -1,0 +1,27 @@
+require 'zipkin-tracer/zipkin_tracer_base'
+require 'zipkin-tracer/careless_scribe'
+
+module Trace
+  class ScribeTracer < ZipkinTracerBase
+    TRACER_CATEGORY = "zipkin".freeze
+
+    def initialize(options)
+      @scribe = CarelessScribe.new(options[:scribe_server])
+      super(options)
+    end
+
+    def flush!
+      @scribe.batch do
+        messages = spans.values.map do |span|
+          buf = ''
+          trans = Thrift::MemoryBufferTransport.new(buf)
+          oprot = Thrift::BinaryProtocol.new(trans)
+          span.to_thrift.write(oprot)
+          Base64.encode64(buf).gsub("\n", "")
+        end
+        @scribe.log(messages, TRACER_CATEGORY)
+      end
+      reset
+    end
+  end
+end

--- a/lib/zipkin-tracer/zipkin_tracer_base.rb
+++ b/lib/zipkin-tracer/zipkin_tracer_base.rb
@@ -8,7 +8,6 @@ module Trace
   # Traces dealing with zipkin should inherit from this class and implement the
   # flush! method which actually sends the information
   class ZipkinTracerBase < Tracer
-    TRACER_CATEGORY = "zipkin".freeze
 
     def initialize(options={})
       @options = options
@@ -16,27 +15,25 @@ module Trace
       reset
     end
 
-    def record(id, annotation)
-      span = get_span_for_id(id)
+    def with_new_span(trace_id, name)
+      span = start_span(trace_id, name)
+      result = yield span
+      may_flush(span)
+      result
+    end
 
-      case annotation
-      when BinaryAnnotation
-        span.binary_annotations << annotation
-      when Annotation
-        span.annotations << annotation
-      end
-      count = current_count
-      set_current_count(count + 1)
-
-      if current_count >= @traces_buffer || (annotation.is_a?(Annotation) && annotation.value == Annotation::SERVER_SEND)
+    def may_flush(span)
+      size = spans.values.map(&:size).inject(:+) || 0
+      if size >= @traces_buffer || span.annotations.any?{ |ann| ann == Annotation::SERVER_SEND }
         flush!
         reset
       end
     end
 
-    def set_rpc_name(id, name)
-      span = get_span_for_id(id)
-      span.name = name.to_s
+    def start_span(trace_id, name)
+      span = get_span_for_id(trace_id)
+      span.name = name
+      span
     end
 
     def flush!
@@ -49,14 +46,6 @@ module Trace
       Thread.current[:zipkin_spans] ||= {}
     end
 
-    def current_count
-      Thread.current[:zipkin_spans_count] ||= 0
-    end
-
-    def set_current_count(count)
-      Thread.current[:zipkin_spans_count] = count
-    end
-
     def get_span_for_id(id)
       key = id.span_id.to_s
       spans[key] ||= Span.new("", id)
@@ -64,7 +53,6 @@ module Trace
 
     def reset
       Thread.current[:zipkin_spans] = {}
-      set_current_count(0)
     end
   end
 end

--- a/spec/lib/tracer_factory_spec.rb
+++ b/spec/lib/tracer_factory_spec.rb
@@ -43,10 +43,11 @@ describe ZipkinTracer::TracerFactory do
     end
 
     context 'configured to use scribe' do
+      require 'zipkin-tracer/zipkin_scribe_tracer'
       let(:config) { configuration(scribe_server: 'fake_scribe_server') }
 
       it 'creates a zipkin kafka tracer' do
-        allow(::Trace::ZipkinTracer).to receive(:new) { tracer }
+        allow(::Trace::ScribeTracer).to receive(:new) { tracer }
         expect(::Trace).to receive(:tracer=).with(tracer)
         expect(described_class.new.tracer(config)).to eq(tracer)
       end


### PR DESCRIPTION
Using spans everywhere, I think logically makes more sense and avoiding using Thread.current gives us a good performance boost.

We went from 100ns in the JSON rack middleware down to 28ns.

@jfeltesse-mdsol  @adriancole @ykitamura-mdsol 
tell me what do you think of this approach