### PR TITLE
Nest local tracing spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 0.12.1
-Nest local tracing spans
+Allow nesting of local tracing spans
 
 # 0.12.0
 Add local tracing, fix flushing, add timestamp and duration to span

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.12.1
+Nest local tracing spans
+
 # 0.12.0
 Add local tracing, fix flushing, add timestamp and duration to span
 

--- a/lib/zipkin-tracer/faraday/zipkin-tracer.rb
+++ b/lib/zipkin-tracer/faraday/zipkin-tracer.rb
@@ -21,7 +21,7 @@ module ZipkinTracer
 
     def call(env)
       trace_id = Trace.id.next_id
-      with_trace_id(trace_id) do
+      Trace.with_trace_id(trace_id) do
         B3_HEADERS.each do |method, header|
           env[:request_headers][header] = trace_id.send(method).to_s
         end
@@ -61,13 +61,6 @@ module ZipkinTracer
         span.record(Trace::Annotation.new(Trace::Annotation::CLIENT_RECV, local_endpoint))
       end
       response
-    end
-
-    def with_trace_id(trace_id, &block)
-      Trace.push(trace_id)
-      yield
-    ensure
-      Trace.pop
     end
 
     def callee_endpoint(url, ip_format)

--- a/lib/zipkin-tracer/rack/zipkin-tracer.rb
+++ b/lib/zipkin-tracer/rack/zipkin-tracer.rb
@@ -34,7 +34,7 @@ module ZipkinTracer
     def call(env)
       zipkin_env = ZipkinEnv.new(env, @config)
       trace_id = zipkin_env.trace_id
-      with_trace_id(trace_id) do
+      Trace.with_trace_id(trace_id) do
         if !trace_id.sampled? || !routable_request?(env)
           @app.call(env)
         else
@@ -46,13 +46,6 @@ module ZipkinTracer
     end
 
     private
-
-    def with_trace_id(trace_id, &block)
-      Trace.push(trace_id)
-      yield
-    ensure
-      Trace.pop
-    end
 
     # If the request is not valid for this service, we do not what to trace it.
     def routable_request?(env)

--- a/lib/zipkin-tracer/trace.rb
+++ b/lib/zipkin-tracer/trace.rb
@@ -8,6 +8,13 @@ module Trace
     @tracer
   end
 
+  def self.with_trace_id(trace_id, &block)
+    self.push(trace_id)
+    yield
+  ensure
+    self.pop
+  end
+
   class Span
     attr_reader :size
     attr_accessor :timestamp, :duration

--- a/lib/zipkin-tracer/trace_client.rb
+++ b/lib/zipkin-tracer/trace_client.rb
@@ -12,9 +12,11 @@ module ZipkinTracer
 
     def initialize(name, &block)
       @trace_id = Trace.id.next_id
-      Trace.tracer.with_new_span(@trace_id, name) do |span|
-        @span = span
-        block.call(self)
+      Trace.with_trace_id(@trace_id) do
+        Trace.tracer.with_new_span(@trace_id, name) do |span|
+          @span = span
+          block.call(self)
+        end
       end
     end
 

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 module ZipkinTracer
-  VERSION = "0.12.0"
+  VERSION = "0.12.1"
 end

--- a/lib/zipkin-tracer/zipkin_tracer_base.rb
+++ b/lib/zipkin-tracer/zipkin_tracer_base.rb
@@ -26,7 +26,7 @@ module Trace
     end
 
     def may_flush(span)
-      size = spans.values.map(&:size).inject(:+) || 0
+      size = spans.values.map(&:size).map(&:to_i).inject(:+) || 0
       if size >= @traces_buffer || span.annotations.any?{ |ann| ann.value == Annotation::SERVER_SEND }
         flush!
         reset

--- a/spec/lib/trace_client_spec.rb
+++ b/spec/lib/trace_client_spec.rb
@@ -107,4 +107,18 @@ describe ZipkinTracer::TraceClient do
       end
     end
   end
+
+  describe 'Local tracing spans are nesting' do
+    it 'have same parent_id but different span_ids' do
+      subject.local_component_span(lc_value) do |ztc|
+        parent_local_trace = Trace.id
+        subject.local_component_span(lc_value) do |ztc|
+
+          expect(parent_local_trace.trace_id).to eq(Trace.id.trace_id)
+          expect(parent_local_trace.span_id).not_to eq(Trace.id.span_id)
+
+        end
+      end
+    end
+  end
 end

--- a/spec/lib/trace_client_spec.rb
+++ b/spec/lib/trace_client_spec.rb
@@ -113,10 +113,9 @@ describe ZipkinTracer::TraceClient do
       subject.local_component_span(lc_value) do |ztc|
         parent_local_trace = Trace.id
         subject.local_component_span(lc_value) do |ztc|
-
           expect(parent_local_trace.trace_id).to eq(Trace.id.trace_id)
           expect(parent_local_trace.span_id).not_to eq(Trace.id.span_id)
-
+          expect(Trace.id.parent_id).to eq(parent_local_trace.span_id)
         end
       end
     end


### PR DESCRIPTION
Modify to nest local tracing spans. 

Example:
```ruby
    ZipkinTracer::TraceClient.local_component_span("Sleeping here") do |ztc|
      ztc.record 'New Annotation'
      sleep 5
      ZipkinTracer::TraceClient.local_component_span("I'm awake!!") do |aztc|
        aztc.record 'Ohayo'
      end
    end
```

Please review.

@jfeltesse-mdsol @jcarres-mdsol @cabbott @ssteeg-mdsol