### PR TITLE
Make local tracing method returns the result of block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.12.2
+Make local tracing method (ZipkinTracer::TraceClient.local_component_span) returns the result of block
+
 # 0.12.1
 Allow nesting of local tracing spans
 

--- a/README.md
+++ b/README.md
@@ -69,10 +69,11 @@ When `local_component_span` method is called, it creates a new span and a local 
 
 Example:
 ```ruby
-ZipkinTracer::TraceClient.local_component_span('Local Trace') do |ztc|
-  ztc.record 'New Annotation'
-  ztc.record_tag 'key', 'sample'
-  # target process
+ZipkinTracer::TraceClient.local_component_span('DB process') do |ztc|
+  ztc.record 'Create users'
+  ztc.record_tag 'number', '1000'
+
+  # create 1000 users
 end
 ```
 

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 module ZipkinTracer
-  VERSION = "0.12.1"
+  VERSION = "0.12.2"
 end

--- a/spec/lib/trace_client_spec.rb
+++ b/spec/lib/trace_client_spec.rb
@@ -5,6 +5,7 @@ describe ZipkinTracer::TraceClient do
   let(:lc_value) { 'lc_value' }
   let(:key) { 'key' }
   let(:value) { 'value' }
+  let(:result) { 'result' }
   subject { ZipkinTracer::TraceClient }
 
   before do
@@ -82,12 +83,15 @@ describe ZipkinTracer::TraceClient do
 
         subject.local_component_span(lc_value) {}
       end
+
+      it 'returns the result of block' do
+        expect(subject.local_component_span(lc_value) { result } ).to eq('result')
+      end
     end
 
     context 'called without block' do
-      it 'creates no span' do
-        expect(Trace.tracer).not_to receive(:with_new_span)
-        subject.local_component_span(lc_value)
+      it 'raises argument error' do
+        expect{ subject.local_component_span(lc_value) }.to raise_error(ArgumentError, 'no block given')
       end
     end
   end


### PR DESCRIPTION
Modify local tracing method to return the result of block.

Now you can just wrap process even if you want to use the result.

```ruby
    def self.all
      all_items = Resource.items
      add_information(all_items)
      all_items
    end
```
:arrow_down:

```ruby
    def self.all
      ZipkinTracer::TraceClient.local_component_span("Services Data") do
        all_items = Resource.items
        add_information(all_items)
        all_items
      end
    end
```

Please review.

@jfeltesse-mdsol @jcarres-mdsol @cabbott @ssteeg-mdsol