### PR TITLE
remove support for traces buffering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.13.0
+Do not support buffering. It was broken anyways.
+
 # 0.12.1
 Allow nesting of local tracing spans
 

--- a/README.md
+++ b/README.md
@@ -22,10 +22,8 @@ where `Rails.config.zipkin_tracer` or `config` is a hash that can contain the fo
 * `:sample_rate` (default: 0.1) - the ratio of requests to sample, from 0 to 1
 * `:logger` - A logger class following the standard's library Logger interface (Log4r, Rails.logger, etc).
 * `:json_api_host` - hostname with protocol of a zipkin api instance (e.g. `https://zipkin.example.com`) to use the JSON tracer
-* `:traces_buffer` (default: 100) - the number of annotations stored by the JSON tracer until automatic flush (note that annotations are also flushed when the request is complete)
 * `:zookeeper` - the address of the zookeeper server to use by the Kafka tracer
 * `:scribe_server` (default from scribe gem) - the address of the scribe server where traces are delivered
-* `:scribe_max_buffer` (default: 10) - the number of annotations stored by the Scribe tracer until automatic flush (note that annotations are also flushed when the request is complete)
 * `:annotate_plugin` - plugin function which receives the Rack env, the response status, headers, and body to record annotations
 * `:filter_plugin` - plugin function which receives the Rack env and will skip tracing if it returns false
 * `:whitelist_plugin` - plugin function which receives the Rack env and will force sampling if it returns true
@@ -84,8 +82,6 @@ end
 Sends traces as JSON over HTTP. This is the preferred tracer to use as the openzipkin project moves away from Thrift.
 
 You need to specify the `:json_api_host` parameter to wherever your zipkin collector is running. It will POST traces to the `/api/v1/spans` path.
-
-By default it buffers the traces call so as not to hammer your zipkin instance. This can be configured using the `:traces_buffer` parameter.
 
 
 ### Kafka

--- a/lib/zipkin-tracer/config.rb
+++ b/lib/zipkin-tracer/config.rb
@@ -4,8 +4,8 @@ require 'zipkin-tracer/application'
 module ZipkinTracer
   # Configuration of this gem. It reads the configuration and provides default values
   class Config
-    attr_reader :service_name, :service_port, :json_api_host, :traces_buffer,
-      :scribe_server, :zookeeper, :sample_rate, :scribe_max_buffer, :annotate_plugin,
+    attr_reader :service_name, :service_port, :json_api_host,
+      :scribe_server, :zookeeper, :sample_rate, :annotate_plugin,
       :filter_plugin, :whitelist_plugin, :logger
 
     def initialize(app, config_hash)
@@ -13,11 +13,9 @@ module ZipkinTracer
       @service_name      = config[:service_name]
       @service_port      = config[:service_port]      || DEFAULTS[:service_port]
       @json_api_host     = config[:json_api_host]
-      @traces_buffer     = config[:traces_buffer]     || DEFAULTS[:traces_buffer]
       @scribe_server     = config[:scribe_server]
       @zookeeper         = config[:zookeeper]
       @sample_rate       = config[:sample_rate]       || DEFAULTS[:sample_rate]
-      @scribe_max_buffer = config[:scribe_max_buffer] || DEFAULTS[:scribe_max_buffer]
       @annotate_plugin   = config[:annotate_plugin]   # call for trace annotation
       @filter_plugin     = config[:filter_plugin]     # skip tracing if returns false
       @whitelist_plugin  = config[:whitelist_plugin]  # force sampling if returns true
@@ -39,8 +37,6 @@ module ZipkinTracer
     private
 
     DEFAULTS = {
-      traces_buffer: 100,
-      scribe_max_buffer: 10,
       sample_rate: 0.1,
       service_port: 80
     }

--- a/lib/zipkin-tracer/trace.rb
+++ b/lib/zipkin-tracer/trace.rb
@@ -28,7 +28,7 @@ module Trace
       @duration = UNKNOWN_DURATION
     end
 
-    def close_span
+    def close
       @duration = to_microseconds(Time.now) - @timestamp
     end
 
@@ -57,6 +57,7 @@ module Trace
     end
 
     private
+
     UNKNOWN_DURATION = 0 # mark duration was not set
 
     def to_microseconds(time)

--- a/lib/zipkin-tracer/tracer_factory.rb
+++ b/lib/zipkin-tracer/tracer_factory.rb
@@ -6,11 +6,11 @@ module ZipkinTracer
       tracer = case adapter
         when :json
           require 'zipkin-tracer/zipkin_json_tracer'
-          options = { json_api_host: config.json_api_host, traces_buffer: config.traces_buffer, logger: config.logger }
+          options = { json_api_host: config.json_api_host, logger: config.logger }
           Trace::ZipkinJsonTracer.new(options)
         when :scribe
           require 'zipkin-tracer/zipkin_scribe_tracer'
-          Trace::ScribeTracer.new(scribe_server: config.scribe_server, traces_buffer: config.scribe_max_buffer)
+          Trace::ScribeTracer.new(scribe_server: config.scribe_server)
         when :kafka
           require 'zipkin-tracer/zipkin_kafka_tracer'
           Trace::ZipkinKafkaTracer.new(zookeepers: config.zookeeper)

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 module ZipkinTracer
-  VERSION = "0.12.1"
+  VERSION = "0.13.0"
 end

--- a/lib/zipkin-tracer/zipkin_kafka_tracer.rb
+++ b/lib/zipkin-tracer/zipkin_kafka_tracer.rb
@@ -12,7 +12,6 @@ module Trace
       @topic  = options[:topic] || DEFAULT_KAFKA_TOPIC
       broker_ids = Hermann::Discovery::Zookeeper.new(options[:zookeepers]).get_brokers
       @producer  = Hermann::Producer.new(nil, broker_ids)
-      options[:traces_buffer] ||= 1  # Default in Kafka is sending as soon as possible. No buffer.
       super(options)
     end
 

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 
 module ZipkinTracer
   RSpec.describe Config do
-    [:service_name, :service_port, :json_api_host, :traces_buffer,
-      :scribe_server, :zookeeper, :sample_rate, :scribe_max_buffer,
+    [:service_name, :service_port, :json_api_host,
+      :scribe_server, :zookeeper, :sample_rate,
       :annotate_plugin, :filter_plugin, :whitelist_plugin, :logger].each do |method|
       it "can set and read configuration values for #{method}" do
         value = rand(100)
@@ -14,7 +14,7 @@ module ZipkinTracer
 
     it 'sets defaults' do
       config = Config.new(nil, {})
-      [:traces_buffer,:sample_rate, :scribe_max_buffer, :service_port].each do |key|
+      [:sample_rate, :service_port].each do |key|
         expect(config.send(key)).to_not eq(nil)
       end
     end

--- a/spec/lib/trace_spec.rb
+++ b/spec/lib/trace_spec.rb
@@ -17,14 +17,12 @@ describe Trace do
       Trace::Span.new('get', Trace::TraceId.new(span_id, parent_id, span_id, true, Trace::Flags::EMPTY))
     end
     let(:timestamp) { 1452987900000000 }
-    let(:duration) { 100000 }
+    let(:duration) { 0 }
 
     before do
+      Timecop.freeze(Time.utc(2016, 1, 16, 23, 45))
       [span_with_parent, span_without_parent].each do |span|
         annotations.each { |a| span.annotations << a }
-
-        span.timestamp = timestamp
-        span.duration = duration
       end
     end
 

--- a/spec/lib/zipkin_kafka_tracer_spec.rb
+++ b/spec/lib/zipkin_kafka_tracer_spec.rb
@@ -36,58 +36,14 @@ if RUBY_PLATFORM == 'java'
 
       context 'with options' do
         let(:topic)  { 'topic' }
-        let(:traces_buffer) { 42 }
 
-        let(:tracer) { described_class.new({traces_buffer: traces_buffer, topic: topic}) }
+        let(:tracer) { described_class.new({ topic: topic }) }
 
         it 'has an optional topic' do
           expect(tracer.instance_variable_get(:@topic)).to eq topic
         end
-        it 'has an optional traces_buffer' do
-          expect(tracer.instance_variable_get(:@traces_buffer)).to eq traces_buffer
-        end
       end
     end
 
-
-    describe '#record' do
-      module MockTrace
-        class BinaryAnnotation < Trace::BinaryAnnotation
-          def initialize;end
-        end
-        class Annotation < Trace::Annotation
-          def initialize;end
-        end
-      end
-
-      let(:binary_annotation) { MockTrace::BinaryAnnotation.new }
-      let(:annotation)        { MockTrace::Annotation.new }
-
-      context 'processing annotation' do
-        before do
-          expect(tracer).to receive(:flush!)
-        end
-
-        it 'records a binary annotation' do
-          tracer.with_new_span(trace_id, name) do |span|
-            span.record(binary_annotation)
-          end
-        end
-        it 'records an annotation' do
-          tracer.with_new_span(trace_id, name) do |span|
-            span.record(binary_annotation)
-          end
-        end
-      end
-    end
-
-    describe '#start_span' do
-      let(:name) { 'name' }
-
-      it 'sets the span name' do
-        expect(span).to receive(:name=).with(name)
-        tracer.start_span(trace_id, name)
-      end
-    end
   end
 end

--- a/spec/lib/zipkin_tracer_base_spec.rb
+++ b/spec/lib/zipkin_tracer_base_spec.rb
@@ -1,0 +1,71 @@
+require 'spec_helper'
+require 'zipkin-tracer/zipkin_tracer_base'
+
+describe Trace::ZipkinTracerBase do
+  let(:span_id) { 'c3a555b04cf7e099' }
+  let(:parent_id) { 'f0e71086411b1445' }
+  let(:sampled) { true }
+  let(:trace_id) { Trace::TraceId.new(span_id, nil, span_id, sampled, Trace::Flags::EMPTY) }
+  let(:rpc_name) { 'this_is_an_rpc' }
+  let(:tracer) { described_class.new }
+  let(:span_hash) { {
+    name: rpc_name,
+    traceId: span_id,
+    id: span_id,
+    parentId: nil,
+    annotations: [],
+    binaryAnnotations: [],
+    timestamp: 1452987900000000,
+    duration: 0,
+    debug: false
+  } }
+  before { Timecop.freeze(Time.utc(2016, 1, 16, 23, 45)) }
+
+  describe '#start_span' do
+    let(:span) { tracer.start_span(trace_id, rpc_name) }
+    let(:rpc_name) { 'this_is_an_rpc' }
+    it 'sets the span name' do
+      expect(span.name).to eq(rpc_name)
+    end
+    it 'returns an empty span' do
+      expect(span.binary_annotations).to eq([])
+      expect(span.annotations).to eq([])
+      expect(span.to_h).to eq(span_hash)
+    end
+  end
+
+  describe '#end_span' do
+    let(:span) { tracer.start_span(trace_id, rpc_name) }
+    it 'flush if SS is annotated in this span' do
+      span.record(Trace::Annotation.new(Trace::Annotation::SERVER_SEND, Trace.default_endpoint))
+      expect(tracer).to receive(:flush!)
+      expect(tracer).to receive(:reset)
+      tracer.end_span(span)
+    end
+    it "does not flush if SS has not been annotated" do
+      span.record(Trace::Annotation.new(Trace::Annotation::SERVER_RECV, Trace.default_endpoint))
+      expect(tracer).not_to receive(:flush!)
+      expect(tracer).not_to receive(:reset)
+      tracer.end_span(span)
+    end
+  end
+
+  describe '#with_new_span' do
+    let(:result) { 'result' }
+    it 'returns the value of the block' do
+      expect(tracer.with_new_span(trace_id, rpc_name) { result }).to eq(result)
+    end
+
+    it "yields the span to the block" do
+      tracer.with_new_span(trace_id, rpc_name) do |span|
+        expect(span.to_h[:traceId]).to eq(trace_id.trace_id.to_s)
+      end
+    end
+    it 'starts and ends a span' do
+      expect(tracer).to receive(:start_span)
+      expect(tracer).to receive(:end_span)
+      tracer.with_new_span(trace_id, rpc_name) { result }
+    end
+  end
+
+end

--- a/spec/support/test_app_config.ru
+++ b/spec/support/test_app_config.ru
@@ -6,7 +6,6 @@ zipkin_tracer_config = {
   service_name: 'your service name here',
   service_port: 9410,
   sample_rate: 1,
-  traces_buffer: 1,
   json_api_host: '127.0.0.1:9410'
 }
 


### PR DESCRIPTION
Deleting support for buffers because we do not do it properly and we want to flush at the end of a request anyways. If ever the support comes back we would need to rethink it anyways.

Also moved some specs around, figured out they were in the wrong place.

@jfeltesse-mdsol  @ykitamura-mdsol  @adriancole 