### PR TITLE
storing in an array instead of a hash

### DIFF
--- a/lib/zipkin-tracer/zipkin_json_tracer.rb
+++ b/lib/zipkin-tracer/zipkin_json_tracer.rb
@@ -29,7 +29,7 @@ module Trace
     end
 
     def flush!
-      AsyncJsonApiClient.new.async.perform(@json_api_host, spans.values.dup)
+      AsyncJsonApiClient.new.async.perform(@json_api_host, spans.dup)
     end
   end
 end

--- a/lib/zipkin-tracer/zipkin_kafka_tracer.rb
+++ b/lib/zipkin-tracer/zipkin_kafka_tracer.rb
@@ -16,7 +16,7 @@ module Trace
     end
 
     def flush!
-      messages = spans.values.map do |span|
+      spans.each do |span|
         buf = ''
         trans = Thrift::MemoryBufferTransport.new(buf)
         oprot = Thrift::BinaryProtocol.new(trans)

--- a/lib/zipkin-tracer/zipkin_scribe_tracer.rb
+++ b/lib/zipkin-tracer/zipkin_scribe_tracer.rb
@@ -12,7 +12,7 @@ module Trace
 
     def flush!
       @scribe.batch do
-        messages = spans.values.map do |span|
+        messages = spans.map do |span|
           buf = ''
           trans = Thrift::MemoryBufferTransport.new(buf)
           oprot = Thrift::BinaryProtocol.new(trans)

--- a/lib/zipkin-tracer/zipkin_tracer_base.rb
+++ b/lib/zipkin-tracer/zipkin_tracer_base.rb
@@ -44,15 +44,15 @@ module Trace
     THREAD_KEY = :zipkin_spans
 
     def spans
-      Thread.current[THREAD_KEY] ||= {}
+      Thread.current[THREAD_KEY] ||= []
     end
 
     def store_span(id, span)
-      spans[id.span_id.to_s] = span
+      spans.push(span)
     end
 
     def reset
-      Thread.current[THREAD_KEY] = {}
+      Thread.current[THREAD_KEY] = []
     end
 
   end


### PR DESCRIPTION
Now that we never retrieve individual spans but all of them at the end of the request, we can use an array directly instead of a hash and then extract the values as array. 

@jfeltesse-mdsol  @ykitamura-mdsol 