### PR TITLE
Check the config entry is not blank when infering adapters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ rvm:
   - 2.2
   - 2.1
   - 2.0
-  - jruby-1.7.23
-  - jruby-9.0.4.0
+  - jruby-1.7.24
+  - jruby-9.0.5.0
 deploy:
   provider: rubygems
   api_key:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.13.1
+* Check the config entry is not blank when infering adapters
+
 # 0.13.0
 * Remove support for buffering. It was broken anyways.
 

--- a/lib/zipkin-tracer/config.rb
+++ b/lib/zipkin-tracer/config.rb
@@ -23,11 +23,11 @@ module ZipkinTracer
     end
 
     def adapter
-      if !!@json_api_host
+      if present?(@json_api_host)
         :json
-      elsif !!@scribe_server
+      elsif present?(@scribe_server)
         :scribe
-      elsif !!@zookeeper && RUBY_PLATFORM == 'java'
+      elsif present?(@zookeeper) && RUBY_PLATFORM == 'java'
         :kafka
       else
         nil
@@ -40,6 +40,11 @@ module ZipkinTracer
       sample_rate: 0.1,
       service_port: 80
     }
+
+    def present?(str)
+      return false if str.nil?
+      !!(/\A[[:space:]]*\z/ !~ str)
+    end
 
   end
 end

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 module ZipkinTracer
-  VERSION = "0.13.0"
+  VERSION = "0.13.1"
 end


### PR DESCRIPTION
Before if the entry was defined but blank we'd use it even though it wouldn't make sense.
With this change we use the NullTracer if the provided configuration entry is blank.

@jcarres-mdsol @ykitamura-mdsol @ssteeg-mdsol