### PR TITLE
Move record methods in TraceClient to Span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.13.2
+* Move record methods in TraceClient to Span
+* Relocate definition of constant variables
+
 # 0.13.1
 * Check the config entry is not blank when infering adapters
 

--- a/lib/zipkin-tracer/rack/zipkin-tracer.rb
+++ b/lib/zipkin-tracer/rack/zipkin-tracer.rb
@@ -55,19 +55,19 @@ module ZipkinTracer
       synchronize do
         #if called by a service, the caller already added the information
         trace_request_information(span, zipkin_env.env) unless zipkin_env.called_with_zipkin_headers?
-        span.record(Trace::Annotation.new(Trace::Annotation::SERVER_RECV, Trace.default_endpoint))
-        span.record(Trace::Annotation.new('whitelisted', Trace.default_endpoint)) if zipkin_env.force_sample?
+        span.record(Trace::Annotation::SERVER_RECV)
+        span.record('whitelisted') if zipkin_env.force_sample?
       end
       status, headers, body = yield
     ensure
       synchronize do
         annotate_plugin(zipkin_env.env, status, headers, body)
-        span.record(Trace::Annotation.new(Trace::Annotation::SERVER_SEND, Trace.default_endpoint))
+        span.record(Trace::Annotation::SERVER_SEND)
       end
     end
 
     def trace_request_information(span, env)
-      span.record(Trace::BinaryAnnotation.new('http.uri', env['PATH_INFO'], 'STRING', Trace.default_endpoint))
+      span.record_tag(Trace::BinaryAnnotation::URI, env['PATH_INFO'])
     end
 
     def synchronize(&block)

--- a/lib/zipkin-tracer/trace_client.rb
+++ b/lib/zipkin-tracer/trace_client.rb
@@ -1,8 +1,10 @@
 module ZipkinTracer
-  class TraceClient
-    LOCAL_COMPONENT = 'lc'.freeze
-    STRING_TYPE = 'STRING'.freeze
+  class NullSpan
+    def method_missing(name, *args)
+    end
+  end
 
+  class TraceClient
     def self.local_component_span(local_component_value, &block)
       client = self.new
       client.trace(local_component_value, &block)
@@ -13,26 +15,17 @@ module ZipkinTracer
 
       @trace_id = Trace.id.next_id
       result = nil
-      Trace.with_trace_id(@trace_id) do
-        Trace.tracer.with_new_span(@trace_id, LOCAL_COMPONENT) do |span|
-          @span = span
-          result = block.call(self)
-          record_local_component local_component_value
+      if @trace_id.sampled?
+        Trace.with_trace_id(@trace_id) do
+          Trace.tracer.with_new_span(@trace_id, Trace::BinaryAnnotation::LOCAL_COMPONENT) do |span|
+            result = block.call(span)
+            span.record_local_component local_component_value
+          end
         end
+      else
+        result = block.call(NullSpan.new)
       end
       result
-    end
-
-    def record(key)
-      @span.record(Trace::Annotation.new(key, Trace.default_endpoint)) if @trace_id.sampled?
-    end
-
-    def record_tag(key, value)
-      @span.record(Trace::BinaryAnnotation.new(key, value, STRING_TYPE, Trace.default_endpoint)) if @trace_id.sampled?
-    end
-
-    def record_local_component(value)
-      record_tag(LOCAL_COMPONENT, value)
     end
 
   end

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 module ZipkinTracer
-  VERSION = "0.13.1"
+  VERSION = "0.13.2"
 end

--- a/spec/lib/faraday/zipkin-tracer_spec.rb
+++ b/spec/lib/faraday/zipkin-tracer_spec.rb
@@ -58,30 +58,33 @@ describe ZipkinTracer::FaradayHandler do
     def expect_tracing
       expect(tracer).to receive(:with_new_span).with(anything, 'post').and_call_original
 
-      expect_any_instance_of(Trace::Span).to receive(:record).with(instance_of(Trace::BinaryAnnotation)) do |_, ann|
-        expect(ann.key).to eq('http.uri')
-        expect(ann.value).to eq(url_path)
+      expect_any_instance_of(Trace::Span).to receive(:record_tag) do |_, key, value, type, host|
+        expect(key).to eq('http.uri')
+        expect(value).to eq(url_path)
+        expect_host(host, '127.0.0.1', service_name)
       end
 
-      expect_any_instance_of(Trace::Span).to receive(:record).with(instance_of(Trace::BinaryAnnotation)) do |_, ann|
-        expect(ann.key).to eq('sa')
-        expect(ann.value).to eq('1')
-        expect_host(ann.host, host_ip, service_name)
+      expect_any_instance_of(Trace::Span).to receive(:record_tag) do |_, key, value, type, host|
+        expect(key).to eq('sa')
+        expect(value).to eq('1')
+        expect(type).to eq('BOOL')
+        expect_host(host, host_ip, service_name)
       end
 
-      expect_any_instance_of(Trace::Span).to receive(:record).with(instance_of(Trace::BinaryAnnotation)) do |_, ann|
-        expect(ann.key).to eq('http.status')
-        expect(ann.value).to eq('200')
+      expect_any_instance_of(Trace::Span).to receive(:record_tag) do |_, key, value, type, host|
+        expect(key).to eq('http.status')
+        expect(value).to eq('200')
+        expect_host(host, '127.0.0.1', service_name)
       end
 
-      expect_any_instance_of(Trace::Span).to receive(:record).with(instance_of(Trace::Annotation)) do |_, ann|
-        expect(ann.value).to eq(::Trace::Annotation::CLIENT_SEND)
-        expect_host(ann.host, '127.0.0.1', service_name)
+      expect_any_instance_of(Trace::Span).to receive(:record) do |_, value, host|
+        expect(value).to eq(Trace::Annotation::CLIENT_SEND)
+        expect_host(host, '127.0.0.1', service_name)
       end
 
-      expect_any_instance_of(Trace::Span).to receive(:record).with(instance_of(Trace::Annotation)) do |_, ann|
-        expect(ann.value).to eq(::Trace::Annotation::CLIENT_RECV)
-        expect_host(ann.host, '127.0.0.1', service_name)
+      expect_any_instance_of(Trace::Span).to receive(:record) do |_, value, host|
+        expect(value).to eq(Trace::Annotation::CLIENT_RECV)
+        expect_host(host, '127.0.0.1', service_name)
       end
     end
 

--- a/spec/lib/trace_client_spec.rb
+++ b/spec/lib/trace_client_spec.rb
@@ -3,8 +3,6 @@ require 'zipkin-tracer/zipkin_null_tracer'
 
 describe ZipkinTracer::TraceClient do
   let(:lc_value) { 'lc_value' }
-  let(:key) { 'key' }
-  let(:value) { 'value' }
   let(:result) { 'result' }
   subject { ZipkinTracer::TraceClient }
 
@@ -14,74 +12,15 @@ describe ZipkinTracer::TraceClient do
     allow(Trace.id).to receive(:next_id).and_return(Trace::TraceId.new(1, 2, 3, true, ::Trace::Flags::DEBUG))
   end
 
-  def expect_new_span
-    expect(Trace.tracer).to receive(:with_new_span).ordered.with(anything, 'lc').and_call_original
-  end
-
-  def expect_local_componant
-    expect_any_instance_of(Trace::Span).to receive(:record).with(instance_of(Trace::BinaryAnnotation)) do |_, ann|
-      expect(ann.key).to eq('lc')
-      expect(ann.value).to eq(lc_value)
-    end
-  end
-
-  describe '#record' do
-    it 'records an annotation' do
-      expect_new_span
-
-      expect_any_instance_of(Trace::Span).to receive(:record).with(instance_of(Trace::Annotation)) do |_, ann|
-        expect(ann.value).to eq('value')
-      end
-
-      expect_local_componant
-
-      subject.local_component_span(lc_value) do |ztc|
-        ztc.record(value)
-      end
-    end
-  end
-
-  describe '#record_tag' do
-    it 'records a binary annotation' do
-      expect_new_span
-
-      expect_any_instance_of(Trace::Span).to receive(:record).with(instance_of(Trace::BinaryAnnotation)) do |_, ann|
-        expect(ann.key).to eq('key')
-        expect(ann.value).to eq('value')
-      end
-
-      expect_local_componant
-
-      subject.local_component_span(lc_value) do |ztc|
-        ztc.record_tag(key, value)
-      end
-    end
-  end
-
-  describe '#record_local_component' do
-    it 'records a binary annotation ' do
-      expect_new_span
-
-      expect_any_instance_of(Trace::Span).to receive(:record).with(instance_of(Trace::BinaryAnnotation)) do |_, ann|
-        expect(ann.key).to eq('lc')
-        expect(ann.value).to eq('value')
-      end
-
-      expect_local_componant
-
-      subject.local_component_span(lc_value) do |ztc|
-        ztc.record_local_component(value)
-      end
-    end
-  end
-
   describe '.local_component_span' do
     context 'called with block' do
       it 'creates new span' do
-        expect_new_span
-        expect_local_componant
+        expect(Trace.tracer).to receive(:with_new_span).ordered.with(anything, 'lc').and_call_original
+        expect_any_instance_of(Trace::Span).to receive(:record_local_component).with('lc_value')
 
-        subject.local_component_span(lc_value) {}
+        subject.local_component_span(lc_value) do |ztc|
+          ztc.record('value')
+        end
       end
 
       it 'returns the result of block' do
@@ -101,14 +40,16 @@ describe ZipkinTracer::TraceClient do
       allow(Trace.id).to receive(:next_id).and_return(Trace::TraceId.new(1, 2, 3, false, 0))
     end
 
-    it 'does not record annotations' do
-      expect_new_span
-
-      expect_any_instance_of(Trace::Span).not_to receive(:record)
+    it 'does not create new span' do
+      expect(Trace.tracer).not_to receive(:with_new_span)
 
       subject.local_component_span(lc_value) do |ztc|
-        ztc.record(value)
+        ztc.record('value')
       end
+    end
+
+    it 'returns the result of block' do
+      expect(subject.local_component_span(lc_value) { result } ).to eq('result')
     end
   end
 

--- a/spec/lib/trace_spec.rb
+++ b/spec/lib/trace_spec.rb
@@ -18,12 +18,15 @@ describe Trace do
     end
     let(:timestamp) { 1452987900000000 }
     let(:duration) { 0 }
+    let(:key) { 'key' }
+    let(:value) { 'value' }
 
     before do
       Timecop.freeze(Time.utc(2016, 1, 16, 23, 45))
       [span_with_parent, span_without_parent].each do |span|
         annotations.each { |a| span.annotations << a }
       end
+      allow(Trace).to receive(:default_endpoint).and_return(Trace::Endpoint.new('127.0.0.1', '80', 'service_name'))
     end
 
     describe '#to_h' do
@@ -43,6 +46,36 @@ describe Trace do
         expect(span_with_parent.to_h).to eq(expected_hash.merge(parentId: parent_id))
       end
     end
+
+    describe '#record' do
+      it 'records an annotation' do
+        span_with_parent.record(value)
+
+        ann = span_with_parent.annotations[-1]
+        expect(ann.value).to eq('value')
+      end
+    end
+
+    describe '#record_tag' do
+      it 'records a binary annotation' do
+        span_with_parent.record_tag(key, value)
+
+        ann = span_with_parent.binary_annotations[-1]
+        expect(ann.key).to eq('key')
+        expect(ann.value).to eq('value')
+      end
+    end
+
+    describe '#record_local_component' do
+      it 'records a binary annotation ' do
+        span_with_parent.record_local_component(value)
+
+        ann = span_with_parent.binary_annotations[-1]
+        expect(ann.key).to eq('lc')
+        expect(ann.value).to eq('value')
+      end
+    end
+
   end
 
   describe Trace::Annotation do

--- a/spec/lib/zipkin_tracer_base_spec.rb
+++ b/spec/lib/zipkin_tracer_base_spec.rb
@@ -46,6 +46,7 @@ describe Trace::ZipkinTracerBase do
 
   describe '#end_span' do
     let(:span) { tracer.start_span(trace_id, rpc_name) }
+    before { allow(Trace).to receive(:default_endpoint).and_return(Trace::Endpoint.new('127.0.0.1', '80', 'service_name')) }
     it 'closes the span' do
       span #touch it so it happens before we freeze time again
       Timecop.freeze(Time.utc(2016, 1, 16, 23, 45, 1))
@@ -53,13 +54,13 @@ describe Trace::ZipkinTracerBase do
       expect(span.to_h).to eq(span_hash.merge(duration: 1_000_000))
     end
     it 'flush if SS is annotated in this span' do
-      span.record(Trace::Annotation.new(Trace::Annotation::SERVER_SEND, Trace.default_endpoint))
+      span.record(Trace::Annotation::SERVER_SEND)
       expect(tracer).to receive(:flush!)
       expect(tracer).to receive(:reset)
       tracer.end_span(span)
     end
     it "does not flush if SS has not been annotated" do
-      span.record(Trace::Annotation.new(Trace::Annotation::SERVER_RECV, Trace.default_endpoint))
+      span.record(Trace::Annotation::SERVER_RECV)
       expect(tracer).not_to receive(:flush!)
       expect(tracer).not_to receive(:reset)
       tracer.end_span(span)


### PR DESCRIPTION
Refactoring Span class, moving record methods in TraceClient class to Span. Update other classes to use the new methods.

Also, relocate BinaryAnnotation's constant variables to appropriate position. BinaryAnnotation types are defined here (http://www.rubydoc.info/gems/finagle-thrift/1.4.1/Trace/BinaryAnnotation/Type).

Please review  

@jfeltesse-mdsol @jcarres-mdsol @cabbott @ssteeg-mdsol 