### PR TITLE
adds a logger tracer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.14.0
+* Adds a logger kind of tracer.
+
 # 0.13.2
 * Move record methods in TraceClient to Span
 * Relocate definition of constant variables

--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ The original tracer, it uses scribe and thrift to send traces.
 
 You need to explicitly install the gem (`gem 'scribe', '~> 0.2.4'`) and set `:scribe_server` in the config.
 
+### Logger
+
+The simplest tracer that does something. It will log all your spans using the logger you pass in the configuration.
+This tracer can be used for debugging purpose (to see what is going to be sent) or to deliver zipkin information into the logs for later retrieval and analysis.
+
+You need to set `:logger` in the configuration.
 
 ### Null
 

--- a/lib/zipkin-tracer/config.rb
+++ b/lib/zipkin-tracer/config.rb
@@ -20,6 +20,7 @@ module ZipkinTracer
       @filter_plugin     = config[:filter_plugin]     # skip tracing if returns false
       @whitelist_plugin  = config[:whitelist_plugin]  # force sampling if returns true
       @logger            = config[:logger]            || Application.logger
+      @logger_setup      = config[:logger]            # Was the logger in fact setup by the client?
     end
 
     def adapter
@@ -29,6 +30,8 @@ module ZipkinTracer
         :scribe
       elsif present?(@zookeeper) && RUBY_PLATFORM == 'java'
         :kafka
+      elsif @logger_setup
+        :logger
       else
         nil
       end

--- a/lib/zipkin-tracer/tracer_factory.rb
+++ b/lib/zipkin-tracer/tracer_factory.rb
@@ -14,6 +14,9 @@ module ZipkinTracer
         when :kafka
           require 'zipkin-tracer/zipkin_kafka_tracer'
           Trace::ZipkinKafkaTracer.new(zookeepers: config.zookeeper)
+        when :logger
+          require 'zipkin-tracer/zipkin_logger_tracer'
+          Trace::ZipkinLoggerTracer.new(logger: config.logger)
         else
           require 'zipkin-tracer/zipkin_null_tracer'
           Trace::NullTracer.new

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 module ZipkinTracer
-  VERSION = "0.13.2"
+  VERSION = "0.14.0"
 end

--- a/lib/zipkin-tracer/zipkin_logger_tracer.rb
+++ b/lib/zipkin-tracer/zipkin_logger_tracer.rb
@@ -1,0 +1,15 @@
+require 'zipkin-tracer/zipkin_tracer_base'
+
+module Trace
+  class ZipkinLoggerTracer < ZipkinTracerBase
+
+    def initialize(options)
+      @logger = options[:logger]
+      super(options)
+    end
+
+    def flush!
+      @logger.info("ZIPKIN SPANS: #{spans.map(&:to_h)}")
+    end
+  end
+end

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -55,6 +55,13 @@ module ZipkinTracer
         end
       end
 
+      context 'logger' do
+        it 'returns :logger if the logger has been set' do
+          config = Config.new(nil, logger: Logger.new(nil))
+          expect(config.adapter).to eq(:logger)
+        end
+      end
+
       context 'kafka' do
         before { stub_const('RUBY_PLATFORM', 'java') }
 

--- a/spec/lib/tracer_factory_spec.rb
+++ b/spec/lib/tracer_factory_spec.rb
@@ -60,6 +60,17 @@ describe ZipkinTracer::TracerFactory do
       end
     end
 
+    context 'configured to use logger' do
+      let(:config) { configuration(logger: Logger.new(nil)) }
+
+      it 'creates a logger tracer' do
+        allow(Trace::ZipkinLoggerTracer).to receive(:new) { tracer }
+        expect(Trace).to receive(:tracer=).with(tracer)
+        expect(described_class.new.tracer(config)).to eq(tracer)
+      end
+    end
+
+
     context 'no transport configured' do
       it 'creates a null tracer' do
         [

--- a/spec/lib/zipkin_logger_tracer_spec.rb
+++ b/spec/lib/zipkin_logger_tracer_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+require 'securerandom'
+require 'zipkin-tracer/zipkin_logger_tracer'
+
+describe Trace::ZipkinLoggerTracer do
+  let(:span_id) { Trace.generate_id }
+  let(:trace_id) { Trace::TraceId.new(span_id, nil, span_id, true, Trace::Flags::EMPTY) }
+  let(:name) { 'trusmis' }
+  let(:logger) { Logger.new(nil) }
+
+  describe '#flush!' do
+    it 'flushes the list of spans into the log' do
+      tracer = Trace::ZipkinLoggerTracer.new(logger: logger)
+      the_span = nil
+      tracer.with_new_span(trace_id, name) do |span|
+        the_span = span
+        span.record_tag('test', 'prueba')
+      end
+
+      log_text = "ZIPKIN SPANS: #{[the_span.to_h]}"
+      expect(logger).to receive(:info).with(log_text)
+      tracer.flush!
+    end
+  end
+end


### PR DESCRIPTION
It is always difficult to know what we would be sending.
This tracer let us see what would be sent. It also may be used if someone wants to send zipkin info to the logs instead of directly to the server.
@jfeltesse-mdsol  @ykitamura-mdsol 