### PR TITLE
access to tracer later in faraday so it does not depend on it being set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.14.1
+* Access to the tracer when we need it and not before.
+
 # 0.14.0
 * Adds a logger kind of tracer.
 

--- a/lib/zipkin-tracer/faraday/zipkin-tracer.rb
+++ b/lib/zipkin-tracer/faraday/zipkin-tracer.rb
@@ -17,7 +17,6 @@ module ZipkinTracer
     def initialize(app, service_name = nil)
       @app = app
       @service_name = service_name
-      @tracer = Trace.tracer
     end
 
     def call(env)
@@ -43,7 +42,7 @@ module ZipkinTracer
       url = env[:url].respond_to?(:host) ? env[:url] : URI.parse(env[:url].to_s)
       local_endpoint = Trace.default_endpoint # The rack middleware set this up for us.
       remote_endpoint = Trace::Endpoint.remote_endpoint(url, @service_name, local_endpoint.ip_format) # The endpoint we are calling.
-      @tracer.with_new_span(trace_id, env[:method].to_s.downcase) do |span|
+      Trace.tracer.with_new_span(trace_id, env[:method].to_s.downcase) do |span|
         # annotate with method (GET/POST/etc.) and uri path
         span.record_tag(Trace::BinaryAnnotation::URI, url.path, Trace::BinaryAnnotation::Type::STRING, local_endpoint)
         span.record_tag(Trace::BinaryAnnotation::SERVER_ADDRESS, SERVER_ADDRESS_SPECIAL_VALUE, Trace::BinaryAnnotation::Type::BOOL, remote_endpoint)

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 module ZipkinTracer
-  VERSION = "0.14.0"
+  VERSION = "0.14.1"
 end


### PR DESCRIPTION
In some weird cases, like some mocking libraries, it can happen that we store a nil into @tracer and then blow up later.
Do not do that, access tracer when needed, it is fast now anyways.

@jfeltesse-mdsol 