### PR TITLE
Moved host resolution to its own class, do it Async on the JSON tracer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.15.0
+* Hostname resolution done asyncronously for the JSON tracer
+
 # 0.14.1
 * Access to the tracer when we need it and not before.
 

--- a/Rakefile
+++ b/Rakefile
@@ -142,10 +142,10 @@ task :benchmark do
     bm.report("NullTracer + Faraday") { null_tracer_faraday_rack.call(env) }
     bm.report("JSONTracer") { json_tracer_rack.call(env) }
     bm.report("JSONTracer + Faraday") { json_tracer_faraday_rack.call(env) }
-    bm.report("ScribeTracer") { scribe_tracer_rack.call(env) }
-    bm.report("ScribeTracer + Faraday") { scribe_tracer_faraday_rack.call(env) }
     bm.report("Logging Tracer") { logger_tracer_rack.call(env) }
     bm.report("Logging Tracer + Faraday") { logger_tracer_faraday_rack.call(env) }
+    bm.report("ScribeTracer") { scribe_tracer_rack.call(env) }
+    bm.report("ScribeTracer + Faraday") { scribe_tracer_faraday_rack.call(env) }
     bm.compare!
   end
 

--- a/lib/zipkin-tracer/hostname_resolver.rb
+++ b/lib/zipkin-tracer/hostname_resolver.rb
@@ -8,7 +8,7 @@ module ZipkinTracer
 
       each_annotation(spans) do |annotation|
         hostname = annotation.host.ipv4
-        if hostname.to_s =~ /\A[a-z]/ # hostnames start with letters, else we already have an IP
+        if hostname.to_s =~ /\A[a-zA-Z]/ # hostnames start with letters, else we already have an IP
           annotation.host.ipv4 = host_to_ip[hostname]
         end
       end
@@ -53,7 +53,7 @@ module ZipkinTracer
 
     def host_to_ip(hostname, ip_format)
       ipv4 = begin
-        ip_format == :string ? Socket.getaddrinfo(hostname, nil, :INET).first[IP_FIELD] : host_to_i32(hostname)
+        ip_format == :string ? Socket.getaddrinfo(hostname, nil, :INET).first[IP_FIELD] : Trace::Endpoint.host_to_i32(hostname)
       rescue
         ip_format == :string ? LOCALHOST : LOCALHOST_I32
       end

--- a/lib/zipkin-tracer/hostname_resolver.rb
+++ b/lib/zipkin-tracer/hostname_resolver.rb
@@ -1,0 +1,63 @@
+module ZipkinTracer
+  # Resolves hostnames in the endpoints of the annotations.
+  # Resolving hostnames is a very expensive operation. We want to store them raw in the main thread
+  # and resolve them in a different thread where we do not affect execution times.
+  class HostnameResolver
+    def spans_with_ips(spans)
+      host_to_ip = hosts_to_ipv4(spans)
+
+      each_annotation(spans) do |annotation|
+        hostname = annotation.host.ipv4
+        if hostname.to_s =~ /\A[a-z]/ # hostnames start with letters, else we already have an IP
+          annotation.host.ipv4 = host_to_ip[hostname]
+        end
+      end
+    end
+
+    private
+    LOCALHOST = '127.0.0.1'.freeze
+    LOCALHOST_I32 = 0x7f000001.freeze
+    IP_FIELD = 3
+
+    def each_annotation(spans, &block)
+      spans.each do |span|
+        span.annotations.each do |annotation|
+          yield annotation
+        end
+        span.binary_annotations.each do |annotation|
+          yield annotation
+        end
+      end
+    end
+
+    # Annotations come in pairs like CS/CR, SS/SR.
+    # Each annnotation has a hostname so we, for sure, will have the same host multiple times.
+    # Using this to resolve only once per host
+    def hosts_to_ipv4(spans)
+      hosts = []
+      each_annotation(spans) do |annotation|
+        hosts.push(annotation.host)
+      end
+      hosts.uniq!
+      resolve(hosts)
+    end
+
+    def resolve(hosts)
+      hosts.inject({}) do |host_map, host|
+        hostname = host.ipv4  # This field has been temporarly used to store the hostname.
+        ip_format = host.ip_format
+        host_map[hostname]  = host_to_ip(hostname, ip_format)
+        host_map
+      end
+    end
+
+    def host_to_ip(hostname, ip_format)
+      ipv4 = begin
+        ip_format == :string ? Socket.getaddrinfo(hostname, nil, :INET).first[IP_FIELD] : host_to_i32(hostname)
+      rescue
+        ip_format == :string ? LOCALHOST : LOCALHOST_I32
+      end
+    end
+  end
+
+end

--- a/lib/zipkin-tracer/trace.rb
+++ b/lib/zipkin-tracer/trace.rb
@@ -38,8 +38,8 @@ module Trace
         traceId: @span_id.trace_id.to_s,
         id: @span_id.span_id.to_s,
         parentId: @span_id.parent_id.nil? ? nil : @span_id.parent_id.to_s,
-        annotations: @annotations.map!(&:to_h),
-        binaryAnnotations: @binary_annotations.map!(&:to_h),
+        annotations: @annotations.map(&:to_h),
+        binaryAnnotations: @binary_annotations.map(&:to_h),
         timestamp: @timestamp,
         duration: @duration,
         debug: @debug
@@ -97,8 +97,6 @@ module Trace
 
   # This class is defined in finagle-thrift. We are adding extra methods here
   class Endpoint
-    LOCALHOST = '127.0.0.1'.freeze
-    LOCALHOST_I32 = 0x7f000001.freeze
     UNKNOWN_URL = 'unknown'.freeze
 
     # we cannot override the initializer to add an extra parameter so use a factory
@@ -124,13 +122,7 @@ module Trace
 
     private
     def self.make_endpoint(hostname, service_port, service_name, ip_format)
-      ipv4 = begin
-        ip_format == :string ? Socket.getaddrinfo(hostname, nil, :INET)[0][3] : host_to_i32(hostname)
-      rescue
-        ip_format == :string ? LOCALHOST : LOCALHOST_I32
-      end
-
-      ep = Endpoint.new(ipv4, service_port, service_name)
+      ep = Endpoint.new(hostname, service_port, service_name)
       ep.ip_format = ip_format
       ep
     end

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 module ZipkinTracer
-  VERSION = "0.14.1"
+  VERSION = '0.15.0'.freeze
 end

--- a/lib/zipkin-tracer/zipkin_json_tracer.rb
+++ b/lib/zipkin-tracer/zipkin_json_tracer.rb
@@ -1,16 +1,18 @@
 require 'json'
 require 'sucker_punch'
 require 'zipkin-tracer/zipkin_tracer_base'
+require 'zipkin-tracer/hostname_resolver'
 
 class AsyncJsonApiClient
   include SuckerPunch::Job
   SPANS_PATH = '/api/v1/spans'
 
   def perform(json_api_host, spans)
+    spans_with_ips = ::ZipkinTracer::HostnameResolver.new.spans_with_ips(spans).map(&:to_h)
     resp = Faraday.new(json_api_host).post do |req|
       req.url SPANS_PATH
       req.headers['Content-Type'] = 'application/json'
-      req.body = JSON.generate(spans.map!(&:to_h))
+      req.body = JSON.generate(spans_with_ips)
     end
   rescue => e
     SuckerPunch.logger.error(e)

--- a/lib/zipkin-tracer/zipkin_kafka_tracer.rb
+++ b/lib/zipkin-tracer/zipkin_kafka_tracer.rb
@@ -1,6 +1,7 @@
 require 'hermann/producer'
 require 'hermann/discovery/zookeeper'
 require 'zipkin-tracer/zipkin_tracer_base'
+require 'zipkin-tracer/hostname_resolver'
 
 module Trace
   # This class sends information to Zipkin through Kafka.
@@ -16,7 +17,8 @@ module Trace
     end
 
     def flush!
-      spans.each do |span|
+      resolved_spans = ::ZipkinTracer::HostnameResolver.new.spans_with_ips(spans)
+      resolved_spans.each do |span|
         buf = ''
         trans = Thrift::MemoryBufferTransport.new(buf)
         oprot = Thrift::BinaryProtocol.new(trans)

--- a/lib/zipkin-tracer/zipkin_logger_tracer.rb
+++ b/lib/zipkin-tracer/zipkin_logger_tracer.rb
@@ -1,4 +1,5 @@
 require 'zipkin-tracer/zipkin_tracer_base'
+require 'zipkin-tracer/hostname_resolver'
 
 module Trace
   class ZipkinLoggerTracer < ZipkinTracerBase
@@ -9,7 +10,8 @@ module Trace
     end
 
     def flush!
-      @logger.info("ZIPKIN SPANS: #{spans.map(&:to_h)}")
+      formatted_spans = ::ZipkinTracer::HostnameResolver.new.spans_with_ips(spans).map(&:to_h)
+      @logger.info "ZIPKIN SPANS: #{formatted_spans}"
     end
   end
 end

--- a/lib/zipkin-tracer/zipkin_scribe_tracer.rb
+++ b/lib/zipkin-tracer/zipkin_scribe_tracer.rb
@@ -1,5 +1,7 @@
 require 'zipkin-tracer/zipkin_tracer_base'
 require 'zipkin-tracer/careless_scribe'
+require 'zipkin-tracer/hostname_resolver'
+
 
 module Trace
   class ScribeTracer < ZipkinTracerBase
@@ -11,8 +13,9 @@ module Trace
     end
 
     def flush!
+      resolved_spans = ::ZipkinTracer::HostnameResolver.new.spans_with_ips(spans)
       @scribe.batch do
-        messages = spans.map do |span|
+        messages = resolved_spans.map do |span|
           buf = ''
           trans = Thrift::MemoryBufferTransport.new(buf)
           oprot = Thrift::BinaryProtocol.new(trans)

--- a/spec/lib/faraday/zipkin-tracer_spec.rb
+++ b/spec/lib/faraday/zipkin-tracer_spec.rb
@@ -68,7 +68,7 @@ describe ZipkinTracer::FaradayHandler do
         expect(key).to eq('sa')
         expect(value).to eq('1')
         expect(type).to eq('BOOL')
-        expect_host(host, host_ip, service_name)
+        expect_host(host, hostname, service_name)
       end
 
       expect_any_instance_of(Trace::Span).to receive(:record_tag) do |_, key, value, type, host|

--- a/spec/lib/hostname_resolver_spec.rb
+++ b/spec/lib/hostname_resolver_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+require 'zipkin-tracer/hostname_resolver'
+
+describe ZipkinTracer::HostnameResolver do
+  let(:span_id) { 'c3a555b04cf7e099' }
+  let(:parent_id) { 'f0e71086411b1445' }
+  let(:sampled) { true }
+  let(:trace_id) { Trace::TraceId.new(span_id, nil, span_id, sampled, Trace::Flags::EMPTY) }
+  let(:name) { 'raist' }
+  let(:ipv4) { '100.100.100.100' }
+  let(:hostname) { 'www.trusmis.com' }
+  let(:endpoint) { Trace::Endpoint.new(hostname, 80, name) }
+  let(:span) { Trace::Span.new(name, trace_id) }
+  let(:resolved_spans) { described_class.new.spans_with_ips([span]) }
+
+  context 'no spans' do
+    it 'returns an empty array' do
+      expect(described_class.new.spans_with_ips([])).to eq([])
+    end
+  end
+
+  context 'with spans' do
+    before do
+      endpoint.ip_format = :string
+      Trace.default_endpoint = endpoint
+      span.record('diary')
+      span.record_tag('secret', 'book')
+      allow(Socket).to receive(:getaddrinfo).with(hostname, nil, :INET).and_return([[nil, nil, nil, ipv4]])
+    end
+
+    it 'returns an array of spans' do
+      expect(resolved_spans).to be_kind_of(Array)
+    end
+
+    it 'The returned array contains spans' do
+      expect(resolved_spans.first).to be_kind_of(Trace::Span)
+    end
+
+    it 'resolves the hostnames in the annotations' do
+      ip = resolved_spans.first.annotations.first.host.ipv4
+      expect(ip).to eq(ipv4)
+    end
+
+    it 'resolves the hostnames in the binnary annotations' do
+      ip = resolved_spans.first.binary_annotations.first.host.ipv4
+      expect(ip).to eq(ipv4)
+    end
+
+    context 'host lookup failure' do
+      before { allow(Socket).to receive(:getaddrinfo).and_raise }
+      context 'i32' do
+       before { endpoint.ip_format = :i32 }
+        it 'falls back to localhost as an i32' do
+          ip = resolved_spans.first.annotations.first.host.ipv4
+          expect(ip).to eq(0x7f000001)
+        end
+      end
+
+      context 'string' do
+        before { endpoint.ip_format = :string }
+        it 'falls back to localhost as an string' do
+          ip = resolved_spans.first.annotations.first.host.ipv4
+          expect(ip).to eq('127.0.0.1')
+        end
+      end
+    end
+
+  end
+end

--- a/spec/lib/hostname_resolver_spec.rb
+++ b/spec/lib/hostname_resolver_spec.rb
@@ -10,6 +10,8 @@ describe ZipkinTracer::HostnameResolver do
   let(:ipv4) { '100.100.100.100' }
   let(:hostname) { 'www.trusmis.com' }
   let(:endpoint) { Trace::Endpoint.new(hostname, 80, name) }
+  let(:local_hostname) { 'MRBADGUY' }
+  let(:local_endpoint) { Trace::Endpoint.new(local_hostname, 80, name) }
   let(:span) { Trace::Span.new(name, trace_id) }
   let(:resolved_spans) { described_class.new.spans_with_ips([span]) }
 
@@ -19,15 +21,8 @@ describe ZipkinTracer::HostnameResolver do
     end
   end
 
-  context 'with spans' do
-    before do
-      endpoint.ip_format = :string
-      Trace.default_endpoint = endpoint
-      span.record('diary')
-      span.record_tag('secret', 'book')
-      allow(Socket).to receive(:getaddrinfo).with(hostname, nil, :INET).and_return([[nil, nil, nil, ipv4]])
-    end
 
+  shared_examples_for 'resolves hostnames' do
     it 'returns an array of spans' do
       expect(resolved_spans).to be_kind_of(Array)
     end
@@ -38,18 +33,18 @@ describe ZipkinTracer::HostnameResolver do
 
     it 'resolves the hostnames in the annotations' do
       ip = resolved_spans.first.annotations.first.host.ipv4
-      expect(ip).to eq(ipv4)
+      expect(ip).to eq(expected_ip)
     end
 
     it 'resolves the hostnames in the binnary annotations' do
       ip = resolved_spans.first.binary_annotations.first.host.ipv4
-      expect(ip).to eq(ipv4)
+      expect(ip).to eq(expected_ip)
     end
 
     context 'host lookup failure' do
       before { allow(Socket).to receive(:getaddrinfo).and_raise }
       context 'i32' do
-       before { endpoint.ip_format = :i32 }
+       before { current_endpoint.ip_format = :i32 }
         it 'falls back to localhost as an i32' do
           ip = resolved_spans.first.annotations.first.host.ipv4
           expect(ip).to eq(0x7f000001)
@@ -57,13 +52,55 @@ describe ZipkinTracer::HostnameResolver do
       end
 
       context 'string' do
-        before { endpoint.ip_format = :string }
+        before { current_endpoint.ip_format = :string }
         it 'falls back to localhost as an string' do
           ip = resolved_spans.first.annotations.first.host.ipv4
           expect(ip).to eq('127.0.0.1')
         end
       end
     end
-
   end
+
+  context 'resolving to i32 addresses' do
+    before do
+      endpoint.ip_format = :i32
+      Trace.default_endpoint = endpoint
+      span.record('diary')
+      span.record_tag('secret', 'book')
+      allow(Socket).to receive(:getaddrinfo).with(hostname, nil).and_return([[nil, nil, nil, ipv4]])
+    end
+    let(:expected_ip) { 1684300900 }  # 1684300900 == 100.100.100.100 into i32 notation
+    let(:current_endpoint) { endpoint }
+
+    it_should_behave_like 'resolves hostnames'
+  end
+
+
+  context 'with spans containing local addresses' do
+    before do
+      local_endpoint.ip_format = :string
+      Trace.default_endpoint = local_endpoint
+      span.record('diary')
+      span.record_tag('secret', 'book')
+      allow(Socket).to receive(:getaddrinfo).with(local_hostname, nil, :INET).and_return([[nil, nil, nil, ipv4]])
+    end
+    let(:expected_ip) { ipv4 }
+    let(:current_endpoint) { local_endpoint }
+    it_should_behave_like 'resolves hostnames'
+  end
+
+
+  context 'with spans resolving to string addresses' do
+    before do
+      endpoint.ip_format = :string
+      Trace.default_endpoint = endpoint
+      span.record('diary')
+      span.record_tag('secret', 'book')
+      allow(Socket).to receive(:getaddrinfo).with(hostname, nil, :INET).and_return([[nil, nil, nil, ipv4]])
+    end
+    let(:expected_ip) { ipv4 }
+    let(:current_endpoint) { endpoint }
+    it_should_behave_like 'resolves hostnames'
+  end
+
 end

--- a/spec/lib/rack/zipkin-tracer_spec.rb
+++ b/spec/lib/rack/zipkin-tracer_spec.rb
@@ -120,12 +120,6 @@ describe ZipkinTracer::RackHandler do
         expect(status).to eq(200)
         expect { |b| body.each &b }.to yield_with_args(app_body)
       end
-
-      it 'errors are logged' do
-        allow_any_instance_of(Trace::Span).to receive(:record).and_raise(StandardError)
-        expect(logger).to receive(:error).with(/Exception StandardError while sending Zipkin traces.*/).twice
-        subject.call(mock_env)
-      end
     end
 
 

--- a/spec/lib/trace_spec.rb
+++ b/spec/lib/trace_spec.rb
@@ -131,32 +131,9 @@ describe Trace do
             and_return([['', '', '', '8.8.8.8']])
         end
 
-        it 'translates a given hostname to an ipv4 as an i32' do
-          ep = ::Trace::Endpoint.make_endpoint(hostname, 80, service_name, :i32)
-          expect(ep.ipv4).to eq(0x8080808)
-          expect(ep.ip_format).to eq(:i32)
-        end
-
-        it 'translates a given hostname to an ipv4 as a string' do
+        it 'does not translate the hostname' do
           ep = ::Trace::Endpoint.make_endpoint(hostname, 80, service_name, :string)
-          expect(ep.ipv4).to eq('8.8.8.8')
-          expect(ep.ip_format).to eq(:string)
-        end
-
-      end
-
-      context 'host lookup failure' do
-        before { allow(Socket).to receive(:gethostname).and_raise }
-
-        it 'falls back to localhost as an i32' do
-          ep = ::Trace::Endpoint.make_endpoint(hostname, 80, service_name, :i32)
-          expect(ep.ipv4).to eq(0x7f000001)
-          expect(ep.ip_format).to eq(:i32)
-        end
-
-        it 'falls back to 127.0.0.1' do
-          ep = ::Trace::Endpoint.make_endpoint(hostname, 80, service_name, :string)
-          expect(ep.ipv4).to eq('127.0.0.1')
+          expect(ep.ipv4).to eq(hostname)
           expect(ep.ip_format).to eq(:string)
         end
       end

--- a/spec/lib/zipkin_logger_tracer_spec.rb
+++ b/spec/lib/zipkin_logger_tracer_spec.rb
@@ -16,7 +16,6 @@ describe Trace::ZipkinLoggerTracer do
         the_span = span
         span.record_tag('test', 'prueba')
       end
-
       log_text = "ZIPKIN SPANS: #{[the_span.to_h]}"
       expect(logger).to receive(:info).with(log_text)
       tracer.flush!

--- a/spec/lib/zipkin_logger_tracer_spec.rb
+++ b/spec/lib/zipkin_logger_tracer_spec.rb
@@ -16,7 +16,8 @@ describe Trace::ZipkinLoggerTracer do
         the_span = span
         span.record_tag('test', 'prueba')
       end
-      log_text = "ZIPKIN SPANS: #{[the_span.to_h]}"
+      spans = ::ZipkinTracer::HostnameResolver.new.spans_with_ips([the_span]).map(&:to_h)
+      log_text = "ZIPKIN SPANS: #{spans}"
       expect(logger).to receive(:info).with(log_text)
       tracer.flush!
     end

--- a/zipkin-tracer.gemspec
+++ b/zipkin-tracer.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'faraday', '~> 0.8'
   s.add_dependency 'finagle-thrift', '~> 1.4.1'
   s.add_dependency 'rack', '~> 1.3'
-  s.add_dependency 'sucker_punch', '~> 1.0'
+  s.add_dependency 'sucker_punch', '~> 1.6'
 
   s.add_development_dependency 'rspec', '~> 3.3'
   s.add_development_dependency 'rack-test', '~> 0.6'


### PR DESCRIPTION

Thanks @ssteeg-mdsol  for the idea on how to solve this.

Moved hostname resolution to a different class. The JSON tracer which was already async now does resolution on a thread instead of stopping the main request.
This improves the speed of the faraday tracer by a crazy 1000% 

Other tracers are not async but they should also get some gains as now we only resolve once per host instead of once everytime we see any host.

@ykitamura-mdsol  @jfeltesse-mdsol  please review