### PR TITLE
less strict dependency on rack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.15.1
+* Less strict dependency on Rack. Allows to use Rails 5.
+
 # 0.15.0
 * Hostname resolution done asyncronously for the JSON tracer
 

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 module ZipkinTracer
-  VERSION = '0.15.0'.freeze
+  VERSION = '0.15.1'.freeze
 end

--- a/zipkin-tracer.gemspec
+++ b/zipkin-tracer.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'faraday', '~> 0.8'
   s.add_dependency 'finagle-thrift', '~> 1.4.1'
-  s.add_dependency 'rack', '~> 1.3'
+  s.add_dependency 'rack', '>= 1.0'
   s.add_dependency 'sucker_punch', '~> 1.6'
 
   s.add_development_dependency 'rspec', '~> 3.3'


### PR DESCRIPTION
Rails 5 depends on rack 2.0 which is compatible, allow it so zipkin can be used there