### PR TITLE
use hermann 0.27.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,5 +11,5 @@ platform :ruby do
 end
 
 platform :jruby do
-  gem 'hermann', github: 'reiseburo/hermann', ref: '436ec9b'
+  gem 'hermann', '~> 0.27.0'
 end

--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ Hermann is the kafka client library that you will need to explicitly install if 
 Caveat: Hermann is only usable from within Jruby, due to its implementation of zookeeper based broker discovery being JVM based.
 
 ```ruby
-# zipkin-kafka-tracer requires Hermann > 0.26.1.0
-gem 'hermann', '> 0.26.1.0'
+# zipkin-kafka-tracer requires Hermann 0.27.0 or later
+gem 'hermann', '~> 0.27.0'
 ```
 
 ### Logger


### PR DESCRIPTION
- the new version has been released so no need to use the ref directly.
- not updating changelog or version because it's a dev only change.
- kept it inside the Gemfile and not gemspec so that MRI users don't have to install hermann for nothing when developing.