### PR TITLE
Allow ZipkinKafkaTracer to use an injected kafka producer instead of hermann

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,15 +88,15 @@ You need to specify the `:json_api_host` parameter to wherever your zipkin colle
 
 Uses Kafka as the transport.
 
-If in the config `:zookeeper` is set, then the gem will use Kafka.
-Hermann is the kafka client library that you will need to explicitly install if you want to use this tracer.
+If in the config `:zookeeper` is set, then the gem will use Kafka via
+[Hermann](https://github.com/reiseburo/hermann); you will need the `hermann`
+gem  (~> 0.27.0) installed, as it is not part of zipkin-tracer's gemspec.
+
+Alternatively, you may provide a :producer option in the config; this producer
+should accept #push() with a message and optional :topic.  If the value returned
+responds to #value!, it will be called (to block until completed).
 
 Caveat: Hermann is only usable from within Jruby, due to its implementation of zookeeper based broker discovery being JVM based.
-
-```ruby
-# zipkin-kafka-tracer requires Hermann 0.27.0 or later
-gem 'hermann', '~> 0.27.0'
-```
 
 ### Logger
 

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 module ZipkinTracer
-  VERSION = '0.16.0'.freeze
+  VERSION = '0.17.0'.freeze
 end

--- a/lib/zipkin-tracer/zipkin_kafka_tracer.rb
+++ b/lib/zipkin-tracer/zipkin_kafka_tracer.rb
@@ -1,5 +1,10 @@
-require 'hermann/producer'
-require 'hermann/discovery/zookeeper'
+# IF hermann isn't present, we might be providing another kafka producer
+begin
+  require 'hermann/producer'
+  require 'hermann/discovery/zookeeper'
+rescue LoadError => e
+end
+
 require 'zipkin-tracer/zipkin_tracer_base'
 require 'zipkin-tracer/hostname_resolver'
 
@@ -11,10 +16,22 @@ module Trace
 
     def initialize(options = {})
       @topic  = options[:topic] || DEFAULT_KAFKA_TOPIC
-      broker_ids = Hermann::Discovery::Zookeeper.new(options[:zookeepers]).get_brokers
-      @producer  = Hermann::Producer.new(nil, broker_ids)
+
+      if options[:producer] && options[:producer].respond_to?(:push)
+        @producer = options[:producer]
+      elsif options[:zookeepers]
+        initialize_hermann_producer(options[:zookeepers])
+      else
+        raise ArgumentError, "No (kafka) :producer option (accepting #push) and no :zookeeper option provided."
+      end
       super(options)
     end
+
+    def initialize_hermann_producer(zookeepers)
+      broker_ids = Hermann::Discovery::Zookeeper.new(zookeepers).get_brokers
+      @producer  = Hermann::Producer.new(nil, broker_ids)
+    end
+    private :initialize_hermann_producer
 
     def flush!
       resolved_spans = ::ZipkinTracer::HostnameResolver.new.spans_with_ips(spans)
@@ -23,7 +40,14 @@ module Trace
         trans = Thrift::MemoryBufferTransport.new(buf)
         oprot = Thrift::BinaryProtocol.new(trans)
         span.to_thrift.write(oprot)
-        @producer.push(buf, topic: @topic).value!
+
+        retval = @producer.push(buf, topic: @topic)
+
+        # If @producer#push returns a promise/promise-like object, block until it
+        # resolves
+        retval.value! if retval.respond_to?(:value!)
+
+        retval
       end
     rescue Exception
       # Ignore socket errors, etc

--- a/lib/zipkin-tracer/zipkin_kafka_tracer.rb
+++ b/lib/zipkin-tracer/zipkin_kafka_tracer.rb
@@ -26,13 +26,6 @@ module Trace
       end
       super(options)
     end
-
-    def initialize_hermann_producer(zookeepers)
-      broker_ids = Hermann::Discovery::Zookeeper.new(zookeepers).get_brokers
-      @producer  = Hermann::Producer.new(nil, broker_ids)
-    end
-    private :initialize_hermann_producer
-
     def flush!
       resolved_spans = ::ZipkinTracer::HostnameResolver.new.spans_with_ips(spans)
       resolved_spans.each do |span|
@@ -51,6 +44,12 @@ module Trace
       end
     rescue Exception
       # Ignore socket errors, etc
+    end
+
+    private
+    def initialize_hermann_producer(zookeepers)
+      broker_ids = Hermann::Discovery::Zookeeper.new(zookeepers).get_brokers
+      @producer  = Hermann::Producer.new(nil, broker_ids)
     end
   end
 end

--- a/spec/lib/zipkin_kafka_tracer_spec.rb
+++ b/spec/lib/zipkin_kafka_tracer_spec.rb
@@ -10,12 +10,11 @@ if RUBY_PLATFORM == 'java'
     let(:sampled) { true }
     let(:trace_id) { Trace::TraceId.new(span_id, nil, span_id, sampled, Trace::Flags::EMPTY) }
     let(:name) { 'test' }
-    let(:tracer) { described_class.new }
+    let(:tracer) { described_class.new(:zookeepers => zookeepers) }
     let(:zookeepers) { 'localhost:2181'     }
     let(:zk)         { double('broker_ids') }
     let(:producer)   { double('producer')   }
     let(:span) { tracer.start_span(trace_id, name) }
-
 
     before do
       allow(Hermann::Discovery::Zookeeper).to receive(:new) { zk }
@@ -26,22 +25,54 @@ if RUBY_PLATFORM == 'java'
     describe '#initialize' do
       context 'with default settings' do
 
+        before do
+          expect(Hermann::Discovery::Zookeeper).to receive(:new) { zk }
+          expect(zk).to receive(:get_brokers)
+          expect(Hermann::Producer).to receive(:new) { producer }
+        end
+
         it 'has default topic' do
           expect(tracer.instance_variable_get(:@topic)).to eq Trace::ZipkinKafkaTracer::DEFAULT_KAFKA_TOPIC
         end
 
-        it 'connects to zookeeper to create the producer' do
+        it 'connects to zookeeper to create a Hermann producer' do
           expect(tracer.instance_variable_get(:@producer)).to eq producer
         end
       end
 
-      context 'with options' do
+      context 'with options including a :topic' do
         let(:topic)  { 'topic' }
 
-        let(:tracer) { described_class.new({ topic: topic }) }
+        let(:tracer) { described_class.new({ :zookeepers => zookeepers, topic: topic }) }
 
         it 'has an optional topic' do
           expect(tracer.instance_variable_get(:@topic)).to eq topic
+        end
+      end
+
+      context 'with options including a :producer' do
+        subject { described_class.new(:producer => mock_producer) }
+
+        let(:mock_producer) { double('Kafka producer', :push => true) }
+
+        it 'should use that producer' do
+          expect(subject.instance_variable_get(:@producer)).to be mock_producer
+        end
+
+        context 'that does not respond_to? #push' do
+          let(:mock_producer) { double('Kafka producer',) }
+
+          it 'should raise ArgumentError' do
+            expect { subject }.to raise_error ArgumentError
+          end
+        end
+      end
+
+      context 'with options including neither a :producer or a :zookeepers' do
+        subject { described_class.new }
+
+        it 'should raise ArgumentError' do
+          expect { subject }.to raise_error ArgumentError
         end
       end
     end

--- a/spec/lib/zipkin_kafka_tracer_spec.rb
+++ b/spec/lib/zipkin_kafka_tracer_spec.rb
@@ -55,14 +55,14 @@ if RUBY_PLATFORM == 'java'
 
         let(:mock_producer) { double('Kafka producer', :push => true) }
 
-        it 'should use that producer' do
+        it 'uses that producer' do
           expect(subject.instance_variable_get(:@producer)).to be mock_producer
         end
 
         context 'that does not respond_to? #push' do
           let(:mock_producer) { double('Kafka producer',) }
 
-          it 'should raise ArgumentError' do
+          it 'raises ArgumentError' do
             expect { subject }.to raise_error ArgumentError
           end
         end
@@ -71,7 +71,7 @@ if RUBY_PLATFORM == 'java'
       context 'with options including neither a :producer or a :zookeepers' do
         subject { described_class.new }
 
-        it 'should raise ArgumentError' do
+        it 'raises ArgumentError' do
           expect { subject }.to raise_error ArgumentError
         end
       end


### PR DESCRIPTION
Leaves the existing API (provide a `:zookeepers` config option, and a corresponding `Hermann::Producer` is created) alone, but adds an alternative `:producer` option that takes a producer that respond_to?s #push.