### PR TITLE
Add a configuration key that actually can make the logger tracer act as such

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.18.0
+* Adds the :log_tracing option to explicitly use the logger tracer.
+* Logger classes can not be passed via the configuration file (never worked correctly).
+* Logger tracer logs in JSON format for easy analysis by other tools.
+
+# 0.17.0
+Adds a :producer configuration key as an alternative to Hermann as Kafka client.
+
 # 0.16.0
 * Remove the scribe tracer.
 * Use sucker_punch 2.x. The main feature is the dependency on concurrent-ruby instead of celluloid.

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ where `Rails.config.zipkin_tracer` or `config` is a hash that can contain the fo
 * `:service_name` **REQUIRED** - the name of the service being traced. There are two ways to configure this value. Either write the service name in the config file or set the "DOMAIN" environment variable (e.g. 'test-service.example.com' or 'test-service'). The environment variable takes precedence over the config file value.
 * `:service_port` **REQUIRED** - the port of the service being traced (e.g. 80 or 443)
 * `:sample_rate` (default: 0.1) - the ratio of requests to sample, from 0 to 1
-* `:logger` - A logger class following the standard's library Logger interface (Log4r, Rails.logger, etc).
 * `:json_api_host` - hostname with protocol of a zipkin api instance (e.g. `https://zipkin.example.com`) to use the JSON tracer
 * `:zookeeper` - the address of the zookeeper server to use by the Kafka tracer
+* `:log_tracing` - Set to true to log all traces. Only used if traces are not sent to the API or Kafka.
 * `:annotate_plugin` - plugin function which receives the Rack env, the response status, headers, and body to record annotations
 * `:filter_plugin` - plugin function which receives the Rack env and will skip tracing if it returns false
 * `:whitelist_plugin` - plugin function which receives the Rack env and will force sampling if it returns true
@@ -77,6 +77,8 @@ end
 
 ## Tracers
 
+Only one of the following tracers can be used at a given time.
+
 ### JSON
 
 Sends traces as JSON over HTTP. This is the preferred tracer to use as the openzipkin project moves away from Thrift.
@@ -100,10 +102,10 @@ Caveat: Hermann is only usable from within Jruby, due to its implementation of z
 
 ### Logger
 
-The simplest tracer that does something. It will log all your spans using the logger you pass in the configuration.
+The simplest tracer that does something. It will log all your spans.
 This tracer can be used for debugging purpose (to see what is going to be sent) or to deliver zipkin information into the logs for later retrieval and analysis.
 
-You need to set `:logger` in the configuration.
+You need to set `:log_tracing` to true in the configuration.
 
 ### Null
 

--- a/lib/zipkin-tracer/config.rb
+++ b/lib/zipkin-tracer/config.rb
@@ -5,7 +5,7 @@ module ZipkinTracer
   # Configuration of this gem. It reads the configuration and provides default values
   class Config
     attr_reader :service_name, :service_port, :json_api_host,
-      :zookeeper, :sample_rate, :logger,
+      :zookeeper, :sample_rate, :logger, :log_tracing,
       :annotate_plugin, :filter_plugin, :whitelist_plugin
 
     def initialize(app, config_hash)
@@ -18,8 +18,8 @@ module ZipkinTracer
       @annotate_plugin   = config[:annotate_plugin]   # call for trace annotation
       @filter_plugin     = config[:filter_plugin]     # skip tracing if returns false
       @whitelist_plugin  = config[:whitelist_plugin]  # force sampling if returns true
-      @logger            = config[:logger]            || Application.logger
-      @logger_setup      = config[:logger]            # Was the logger in fact setup by the client?
+      @logger            = Application.logger
+      @log_tracing       = config[:log_tracing]       # Was the logger in fact setup by the client?
     end
 
     def adapter
@@ -27,7 +27,7 @@ module ZipkinTracer
         :json
       elsif present?(@zookeeper) && RUBY_PLATFORM == 'java'
         :kafka
-      elsif @logger_setup
+      elsif !!@log_tracing
         :logger
       else
         nil

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 module ZipkinTracer
-  VERSION = '0.17.0'.freeze
+  VERSION = '0.18.0'.freeze
 end

--- a/lib/zipkin-tracer/zipkin_logger_tracer.rb
+++ b/lib/zipkin-tracer/zipkin_logger_tracer.rb
@@ -1,17 +1,24 @@
 require 'zipkin-tracer/zipkin_tracer_base'
 require 'zipkin-tracer/hostname_resolver'
+require 'json'
 
 module Trace
   class ZipkinLoggerTracer < ZipkinTracerBase
+    TRACING_KEY = 'Tracing information'
 
     def initialize(options)
       @logger = options[:logger]
+      @logger_accepts_data = @logger.respond_to?(:info_with_data)
       super(options)
     end
 
     def flush!
       formatted_spans = ::ZipkinTracer::HostnameResolver.new.spans_with_ips(spans).map(&:to_h)
-      @logger.info "ZIPKIN SPANS: #{formatted_spans}"
+      if @logger_accepts_data
+        @logger.info_with_data(TRACING_KEY, formatted_spans)
+      else
+        @logger.info({ TRACING_KEY => formatted_spans }.to_json)
+      end
     end
   end
 end

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 module ZipkinTracer
   RSpec.describe Config do
     [:service_name, :service_port, :json_api_host,
-      :zookeeper, :sample_rate, :logger,
+      :zookeeper, :sample_rate, :log_tracing,
       :annotate_plugin, :filter_plugin, :whitelist_plugin].each do |method|
       it "can set and read configuration values for #{method}" do
         value = rand(100)
@@ -47,9 +47,9 @@ module ZipkinTracer
         end
       end
 
-      context 'logger' do
-        it 'returns :logger if the logger has been set' do
-          config = Config.new(nil, logger: Logger.new(nil))
+      context 'log_tracing' do
+        it 'returns :logger if log_tracing has been set to true' do
+          config = Config.new(nil, log_tracing: true)
           expect(config.adapter).to eq(:logger)
         end
       end

--- a/spec/lib/rack/zipkin-tracer_spec.rb
+++ b/spec/lib/rack/zipkin-tracer_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 
 describe ZipkinTracer::RackHandler do
   def middleware(app, config={})
-    configuration = { logger: logger, sample_rate: 1 }.merge(config)
+    configuration = { sample_rate: 1 }.merge(config)
     described_class.new(app, configuration)
   end
 
@@ -20,7 +20,6 @@ describe ZipkinTracer::RackHandler do
   let(:app_headers) { { 'Content-Type' => 'text/plain' } }
   let(:app_body) { path }
   let(:path) { '/'}
-  let(:logger) { Logger.new(nil) }
   let(:tracer) { Trace.tracer }
 
   let(:app) {
@@ -69,6 +68,7 @@ describe ZipkinTracer::RackHandler do
     context 'accessing a valid URL of our service' do
       before do
         rails = double('Rails')
+        allow(rails).to receive(:logger)
         allow(rails).to receive_message_chain(:application, :routes, :recognize_path).and_return(controller: 'trusmis', action: 'new')
         stub_const('Rails', rails)
       end
@@ -78,6 +78,7 @@ describe ZipkinTracer::RackHandler do
     context 'accessing an invalid URL our our service' do
       before do
         rails = double('Rails')
+        allow(rails).to receive(:logger)
         stub_const('ActionController::RoutingError', StandardError)
         allow(rails).to receive_message_chain(:application, :routes, :recognize_path).and_raise(ActionController::RoutingError)
         stub_const('Rails', rails)

--- a/spec/lib/tracer_factory_spec.rb
+++ b/spec/lib/tracer_factory_spec.rb
@@ -50,7 +50,7 @@ describe ZipkinTracer::TracerFactory do
     end
 
     context 'configured to use logger' do
-      let(:config) { configuration(logger: Logger.new(nil)) }
+      let(:config) { configuration(log_tracing: true) }
 
       it 'creates a logger tracer' do
         allow(Trace::ZipkinLoggerTracer).to receive(:new) { tracer }

--- a/spec/lib/zipkin_logger_tracer_spec.rb
+++ b/spec/lib/zipkin_logger_tracer_spec.rb
@@ -10,14 +10,14 @@ describe Trace::ZipkinLoggerTracer do
 
   describe '#flush!' do
     it 'flushes the list of spans into the log' do
-      tracer = Trace::ZipkinLoggerTracer.new(logger: logger)
+      tracer = described_class.new(logger: logger)
       the_span = nil
       tracer.with_new_span(trace_id, name) do |span|
         the_span = span
         span.record_tag('test', 'prueba')
       end
       spans = ::ZipkinTracer::HostnameResolver.new.spans_with_ips([the_span]).map(&:to_h)
-      log_text = "ZIPKIN SPANS: #{spans}"
+      log_text = { described_class::TRACING_KEY => spans }.to_json
       expect(logger).to receive(:info).with(log_text)
       tracer.flush!
     end


### PR DESCRIPTION

I believe there is no easy (not eval or serialization please) way to pass an object through a configuration file. 
So instead of trying that feat, Adding a "log_tracing" so we use logging if other methods are not available.
Also moved the format to be json which should be easier to parse. 

@jfeltesse-mdsol 