### PR TITLE
remove the flags header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.19.0
+* Remove the X-B3-Flags header.
+
 # 0.18.0
 * Adds the :log_tracing option to explicitly use the logger tracer.
 * Logger classes can not be passed via the configuration file (never worked correctly).

--- a/lib/zipkin-tracer/faraday/zipkin-tracer.rb
+++ b/lib/zipkin-tracer/faraday/zipkin-tracer.rb
@@ -10,8 +10,7 @@ module ZipkinTracer
       trace_id: 'X-B3-TraceId',
       parent_id: 'X-B3-ParentSpanId',
       span_id: 'X-B3-SpanId',
-      sampled: 'X-B3-Sampled',
-      flags: 'X-B3-Flags'
+      sampled: 'X-B3-Sampled'
     }.freeze
 
     def initialize(app, service_name = nil)

--- a/lib/zipkin-tracer/rack/zipkin-tracer.rb
+++ b/lib/zipkin-tracer/rack/zipkin-tracer.rb
@@ -22,7 +22,6 @@ module ZipkinTracer
   # It will also send the trace to the Zipkin service using one of the methods configured.
   class RackHandler
     B3_REQUIRED_HEADERS = %w[HTTP_X_B3_TRACEID HTTP_X_B3_PARENTSPANID HTTP_X_B3_SPANID HTTP_X_B3_SAMPLED].freeze
-    B3_OPT_HEADERS = %w[HTTP_X_B3_FLAGS].freeze
 
     def initialize(app, config = nil)
       @app = app
@@ -74,7 +73,7 @@ module ZipkinTracer
         @config = config
       end
 
-      def trace_id(default_flags = Trace::Flags::EMPTY)
+      def trace_id
         trace_parameters = if called_with_zipkin_headers?
                              @env.values_at(*B3_REQUIRED_HEADERS)
                            else
@@ -82,9 +81,7 @@ module ZipkinTracer
                              [new_id, nil, new_id]
                            end
         trace_parameters[3] = should_trace?(trace_parameters[3])
-        trace_parameters += @env.values_at(*B3_OPT_HEADERS) # always check flags
-        trace_parameters[4] = (trace_parameters[4] || default_flags).to_i
-
+        trace_parameters << Trace::Flags::EMPTY # not used but needed because the initializer expects 5 args
         Trace::TraceId.new(*trace_parameters)
       end
 

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 module ZipkinTracer
-  VERSION = '0.18.0'.freeze
+  VERSION = '0.19.0'.freeze
 end

--- a/spec/lib/faraday/zipkin-tracer_spec.rb
+++ b/spec/lib/faraday/zipkin-tracer_spec.rb
@@ -27,7 +27,7 @@ describe ZipkinTracer::FaradayHandler do
   let(:url_path) { '/some/path/here' }
   let(:raw_url) { "https://#{hostname}#{url_path}" }
   let(:tracer) { Trace.tracer }
-  let(:trace_id) { ::Trace::TraceId.new(1, 2, 3, true, ::Trace::Flags::DEBUG) }
+  let(:trace_id) { ::Trace::TraceId.new(1, 2, 3, true, ::Trace::Flags::EMPTY) }
 
   def process(body, url, headers = {})
     env = {
@@ -89,7 +89,7 @@ describe ZipkinTracer::FaradayHandler do
     end
 
     context 'with tracing id' do
-      let(:trace_id) { ::Trace::TraceId.new(1, 2, 3, true, ::Trace::Flags::DEBUG) }
+      let(:trace_id) { ::Trace::TraceId.new(1, 2, 3, true, ::Trace::Flags::EMPTY) }
 
       it 'sets the X-B3 request headers with a new spanID' do
         expect_tracing
@@ -103,7 +103,7 @@ describe ZipkinTracer::FaradayHandler do
         expect(result[:request_headers]['X-B3-SpanId']).not_to eq('0000000000000003')
         expect(result[:request_headers]['X-B3-SpanId']).to match(HEX_REGEX)
         expect(result[:request_headers]['X-B3-Sampled']).to eq('true')
-        expect(result[:request_headers]['X-B3-Flags']).to eq('1')
+        expect(result[:request_headers].key?('X-B3-Flags')).to be false
       end
 
       it 'the original spanID is restored after the calling the middleware' do
@@ -125,7 +125,7 @@ describe ZipkinTracer::FaradayHandler do
         expect(result[:request_headers]['X-B3-ParentSpanId']).to match(HEX_REGEX)
         expect(result[:request_headers]['X-B3-SpanId']).to match(HEX_REGEX)
         expect(result[:request_headers]['X-B3-Sampled']).to match(/(true|false)/)
-        expect(result[:request_headers]['X-B3-Flags']).to match(/(1|0)/)
+        expect(result[:request_headers].key?('X-B3-Flags')).to be false
       end
     end
 
@@ -143,7 +143,7 @@ describe ZipkinTracer::FaradayHandler do
         expect(result[:request_headers]['X-B3-SpanId']).not_to eq('0000000000000003')
         expect(result[:request_headers]['X-B3-SpanId']).to match(HEX_REGEX)
         expect(result[:request_headers]['X-B3-Sampled']).to eq('false')
-        expect(result[:request_headers]['X-B3-Flags']).to eq('0')
+        expect(result[:request_headers].key?('X-B3-Flags')).to be false
       end
 
       it 'the original spanID is restored after the calling the middleware' do

--- a/spec/lib/trace_client_spec.rb
+++ b/spec/lib/trace_client_spec.rb
@@ -37,7 +37,7 @@ describe ZipkinTracer::TraceClient do
 
   describe 'Trace has not been sampled' do
     before do
-      allow(Trace.id).to receive(:next_id).and_return(Trace::TraceId.new(1, 2, 3, false, 0))
+      allow(Trace.id).to receive(:next_id).and_return(Trace::TraceId.new(1, 2, 3, false, ::Trace::Flags::EMPTY))
     end
 
     it 'does not create new span' do


### PR DESCRIPTION
It's not configurable and thus most likely superfluous.

Note: can't nuke all the mentions of the flag because finagle-thrift [expects it](https://github.com/twitter/finagle/blob/develop/finagle-thrift/src/main/ruby/lib/finagle-thrift/trace.rb#L64). Note sure what to do with [this](https://github.com/openzipkin/zipkin-tracer/blob/master/spec/lib/rack/zipkin-tracer_spec.rb#L137-L144) though.


@jcarres-mdsol 
