### PR TITLE
Turn the ZipkinTracer::FaradayHandler::B3_HEADERS constant into a private method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.18.1
+* Turn the ZipkinTracer::FaradayHandler::B3_HEADERS constant into a private method
+
 # 0.18.0
 * Adds the :log_tracing option to explicitly use the logger tracer.
 * Logger classes can not be passed via the configuration file (never worked correctly).

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 module ZipkinTracer
-  VERSION = '0.18.0'.freeze
+  VERSION = '0.18.1'.freeze
 end


### PR DESCRIPTION
Title says it all.

No user facing changes.
This is only to make monkey patching of these easier.

@adriancole @jcarres-mdsol 